### PR TITLE
[FIX] move menuitem for enterprise compatibility

### DIFF
--- a/intrastat_base/views/intrastat.xml
+++ b/intrastat_base/views/intrastat.xml
@@ -10,7 +10,7 @@
     <!-- Menu entries for Intrastat -->
     <menuitem id="menu_intrastat_base_root"
               name="Intrastat"
-              parent="account.menu_finance_legal_statement"/>
+              parent="account.menu_finance_reports"/>
     <menuitem id="menu_intrastat_config_root" name="Intrastat"
               parent="account.menu_finance_configuration" sequence="50"/>
 


### PR DESCRIPTION
The menu 'intrastat_base_root' is based on a menu that is removed by odoo/enterprise.
The goal of this PR is to ensure a compatibility regardless if the user has Community or Enterprise version.
Link to the removal: https://github.com/odoo/enterprise/blob/10.0/account_extension/views/account_report_menu_invisible.xml#L5