### PR TITLE
[8.0] FIX intrastat transaction on refund created from an invoice via the wizard

### DIFF
--- a/intrastat_product/models/account_invoice.py
+++ b/intrastat_product/models/account_invoice.py
@@ -34,7 +34,6 @@ class AccountInvoice(models.Model):
              "commercial terms used in international transactions.")
     intrastat_transaction_id = fields.Many2one(
         'intrastat.transaction', string='Intrastat Transaction Type',
-        default=lambda self: self._default_intrastat_transaction_id(),
         ondelete='restrict',
         help="Intrastat nature of transaction")
     intrastat_transport_id = fields.Many2one(
@@ -63,23 +62,6 @@ class AccountInvoice(models.Model):
             country = inv.src_dest_country_id \
                 or inv.partner_id.country_id
             inv.intrastat_country = country.intrastat
-
-    @api.model
-    def _default_intrastat_transaction_id(self):
-        company = self.env['res.company']
-        company_id = company._company_default_get('account.invoice')
-        company = company.browse(company_id)
-        inv_type = self._context.get('type')
-        if inv_type == 'out_invoice':
-            return company.intrastat_transaction_out_invoice
-        elif inv_type == 'out_refund':
-            return company.intrastat_transaction_out_refund
-        elif inv_type == 'in_invoice':
-            return company.intrastat_transaction_in_invoice
-        elif inv_type == 'in_refund':
-            return company.intrastat_transaction_in_refund
-        else:
-            return self.env['intrastat.transaction']
 
     @api.model
     def _default_src_dest_region_id(self):


### PR DESCRIPTION
Go to the menu "Accounting > Customers > Customer Invoice" and create a customer invoice: the field "Intrastat Transaction Type" gets the default value for Customer Invoices.

Valide the customer invoice.

Click on the button "Refund invoice" and select refund method = "Create a draft refund"

The value of the field "Intrastat Transaction Type" on the refund is the same as the value on the customer invoice -> This is a bug !

Why this bug ? Because, when the customer refund is created via the wizard, the value of the context is still {'type': 'out_invoice'}, so it gets the default value for customer invoices.

2 possible solutions:
1) inherit the method _prepare_refund() to set the value of intrastat_transaction_id to the default value for refunds
2) don't put any default value for the field intrastat_transaction_id because, when we generate the intrastat declaration, it will read the default value from the company configuration. With this solution, we would say to the users: only set this field on an invoice when the default configuration for the company is not appropriate.

This PR implements solution 2).

@luc-demeyer Are you ok with this ? If yes, I'll up-port it to v10.