### PR TITLE
[FIX] Update hs_code to hs_code_id

### DIFF
--- a/product_harmonized_system/README.rst
+++ b/product_harmonized_system/README.rst
@@ -51,6 +51,7 @@ Contributors
 
 * Alexis de Lattre, Akretion <alexis.delattre@akretion.com>
 * Luc De Meyer, Noviat <info@noviat.com>
+* Denis Leemann, Camptocamp SA <denis.leemann@camptocamp.com>
 
 Maintainer
 ----------

--- a/product_harmonized_system/__manifest__.py
+++ b/product_harmonized_system/__manifest__.py
@@ -1,18 +1,21 @@
 # -*- coding: utf-8 -*-
-# © 2011-2016 Akretion (http://www.akretion.com)
-# © 2009-2016 Noviat (http://www.noviat.com)
+# Copyright 2011-2016 Akretion (http://www.akretion.com)
+# Copyright 2009-2016 Noviat (http://www.noviat.com)
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 # @author Luc de Meyer <info@noviat.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     'name': 'Product Harmonized System Codes',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Reporting',
     'license': 'AGPL-3',
     'summary': 'Base module for Product Import/Export reports',
     'author': 'Akretion, Noviat, Odoo Community Association (OCA)',
-    'depends': ['product'],
+    'depends': [
+        'product',
+        'delivery',
+    ],
     'conflicts': ['report_intrastat'],
     'data': [
         'security/product_hs_security.xml',

--- a/product_harmonized_system/demo/product_demo.xml
+++ b/product_harmonized_system/demo/product_demo.xml
@@ -24,55 +24,55 @@
 </record>
 
 <record id="product.product_product_3" model="product.product">
-    <field name="hs_code_id" ref="84715000" />
+    <field name="hs_code" ref="84715000" />
     <field name="origin_country_id" ref="base.tw" />
     <field name="weight">8.7</field>
 </record>
 
 <record id="product.product_product_4" model="product.product">
-    <field name="hs_code_id" ref="84715000" />
+    <field name="hs_code" ref="84715000" />
     <field name="origin_country_id" ref="base.cn" />
     <field name="weight">1.1</field>
 </record>
 
 <record id="product.product_product_5" model="product.product">
-    <field name="hs_code_id" ref="84715000" />
+    <field name="hs_code" ref="84715000" />
     <field name="origin_country_id" ref="base.cn" />
     <field name="weight">8.2</field>
 </record>
 
 <record id="product.product_product_13" model="product.product">
-    <field name="hs_code_id" ref="84717050" />
+    <field name="hs_code" ref="84717050" />
     <field name="origin_country_id" ref="base.sg" />
     <field name="weight">0.01</field>
 </record>
 
 <record id="product.product_product_16" model="product.product">
-    <field name="hs_code_id" ref="84717050" />
+    <field name="hs_code" ref="84717050" />
     <field name="origin_country_id" ref="base.sg" />
     <field name="weight">0.67</field>
 </record>
 
 <record id="product.product_product_17" model="product.product">
-    <field name="hs_code_id" ref="84717050" />
+    <field name="hs_code" ref="84717050" />
     <field name="origin_country_id" ref="base.sg" />
     <field name="weight">0.75</field>
 </record>
 
 <record id="product.product_product_20" model="product.product">
-    <field name="hs_code_id" ref="85340090" />
+    <field name="hs_code" ref="85340090" />
     <field name="origin_country_id" ref="base.tw" />
     <field name="weight">1.05</field>
 </record>
 
 <record id="product.product_product_22" model="product.product">
-    <field name="hs_code_id" ref="85340090" />
+    <field name="hs_code" ref="85340090" />
     <field name="origin_country_id" ref="base.tw" />
     <field name="weight">0.3</field>
 </record>
 
 <record id="product.product_product_25" model="product.product">
-    <field name="hs_code_id" ref="84715000" />
+    <field name="hs_code" ref="84715000" />
     <field name="origin_country_id" ref="base.be" />
     <field name="weight">3.3</field>
 </record>

--- a/product_harmonized_system/i18n/fr.po
+++ b/product_harmonized_system/i18n/fr.po
@@ -67,8 +67,8 @@ msgstr "Nom affiché"
 
 #. module: product_harmonized_system
 #: model:ir.model,name:product_harmonized_system.model_hs_code
-#: field:product.category,hs_code_id:0
-#: field:product.template,hs_code_id:0
+#: field:product.category,hs_code:0
+#: field:product.template,hs_code:0
 msgid "H.S. Code"
 msgstr "Code S.H."
 
@@ -85,12 +85,12 @@ msgid "HS Codes"
 msgstr "Codes S.H."
 
 #. module: product_harmonized_system
-#: help:product.category,hs_code_id:0
+#: help:product.category,hs_code:0
 msgid "Harmonised System Code. If this code is not set on the product itself, it will be read here, on the related product category."
 msgstr ""
 
 #. module: product_harmonized_system
-#: help:product.template,hs_code_id:0
+#: help:product.template,hs_code:0
 msgid "Harmonised System Code. Nomenclature is available from the World Customs Organisation, see http://www.wcoomd.org/. You can leave this field empty and configure the H.S. code on the product category."
 msgstr ""
 

--- a/product_harmonized_system/i18n/product_harmonized_system.pot
+++ b/product_harmonized_system/i18n/product_harmonized_system.pot
@@ -67,8 +67,8 @@ msgstr ""
 
 #. module: product_harmonized_system
 #: model:ir.model,name:product_harmonized_system.model_hs_code
-#: field:product.category,hs_code_id:0
-#: field:product.template,hs_code_id:0
+#: field:product.category,hs_code:0
+#: field:product.template,hs_code:0
 msgid "H.S. Code"
 msgstr ""
 
@@ -85,12 +85,12 @@ msgid "HS Codes"
 msgstr ""
 
 #. module: product_harmonized_system
-#: help:product.category,hs_code_id:0
+#: help:product.category,hs_code:0
 msgid "Harmonised System Code. If this code is not set on the product itself, it will be read here, on the related product category."
 msgstr ""
 
 #. module: product_harmonized_system
-#: help:product.template,hs_code_id:0
+#: help:product.template,hs_code:0
 msgid "Harmonised System Code. Nomenclature is available from the World Customs Organisation, see http://www.wcoomd.org/. You can leave this field empty and configure the H.S. code on the product category."
 msgstr ""
 

--- a/product_harmonized_system/models/hs_code.py
+++ b/product_harmonized_system/models/hs_code.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2011-2016 Akretion (http://www.akretion.com)
-# © 2009-2016 Noviat (http://www.noviat.com)
+# Copyright 2011-2016 Akretion (http://www.akretion.com)
+# Copyright 2009-2016 Noviat (http://www.noviat.com)
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 # @author Luc de Meyer <info@noviat.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -36,9 +36,9 @@ class HSCode(models.Model):
         default=lambda self: self.env['res.company']._company_default_get(
             'hs.code'))
     product_categ_ids = fields.One2many(
-        'product.category', 'hs_code_id', string='Product Categories')
+        'product.category', 'hs_code', string='Product Categories')
     product_tmpl_ids = fields.One2many(
-        'product.template', 'hs_code_id', string='Products')
+        'product.template', 'hs_code', string='Products')
 
     @api.multi
     @api.depends('local_code')

--- a/product_harmonized_system/models/product_category.py
+++ b/product_harmonized_system/models/product_category.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2011-2016 Akretion (http://www.akretion.com)
-# © 2009-2016 Noviat (http://www.noviat.com)
+# Copyright 2011-2016 Akretion (http://www.akretion.com)
+# Copyright 2009-2016 Noviat (http://www.noviat.com)
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 # @author Luc de Meyer <info@noviat.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -11,18 +11,18 @@ from odoo import models, fields, api
 class ProductCategory(models.Model):
     _inherit = "product.category"
 
-    hs_code_id = fields.Many2one(
+    hs_code = fields.Many2one(
         'hs.code', string='H.S. Code',
         company_dependent=True, ondelete='restrict',
         help="Harmonised System Code. If this code is not "
         "set on the product itself, it will be read here, on the "
-        "related product category.")
+        "related product category.", oldname='hs_code_id')
 
     @api.multi
     def get_hs_code_recursively(self):
         self.ensure_one()
-        if self.hs_code_id:
-            res = self.hs_code_id
+        if self.hs_code:
+            res = self.hs_code
         elif self.parent_id:
             res = self.parent_id.get_hs_code_recursively()
         else:

--- a/product_harmonized_system/models/product_template.py
+++ b/product_harmonized_system/models/product_template.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2011-2016 Akretion (http://www.akretion.com)
-# © 2009-2016 Noviat (http://www.noviat.com)
+# Copyright 2011-2016 Akretion (http://www.akretion.com)
+# Copyright 2009-2016 Noviat (http://www.noviat.com)
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 # @author Luc de Meyer <info@noviat.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -11,13 +11,14 @@ from odoo import models, fields, api
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    hs_code_id = fields.Many2one(
+    hs_code = fields.Many2one(
         'hs.code', string='H.S. Code',
         company_dependent=True, ondelete='restrict',
         help="Harmonised System Code. Nomenclature is "
         "available from the World Customs Organisation, see "
         "http://www.wcoomd.org/. You can leave this field empty "
-        "and configure the H.S. code on the product category.")
+        "and configure the H.S. code on the product category.",
+        oldname='hs_code_id')
     origin_country_id = fields.Many2one(
         'res.country', string='Country of Origin',
         help="Country of origin of the product i.e. product "
@@ -26,8 +27,8 @@ class ProductTemplate(models.Model):
     @api.multi
     def get_hs_code_recursively(self):
         self.ensure_one()
-        if self.hs_code_id:
-            res = self.hs_code_id
+        if self.hs_code:
+            res = self.hs_code
         elif self.categ_id:
             res = self.categ_id.get_hs_code_recursively()
         else:

--- a/product_harmonized_system/views/hs_code.xml
+++ b/product_harmonized_system/views/hs_code.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  © 2010-2016 Akretion (http://www.akretion.com/)
+  Copyright 2010-2016 Akretion (http://www.akretion.com/)
   @author Alexis de Lattre <alexis.delattre@akretion.com>
   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->

--- a/product_harmonized_system/views/product_category.xml
+++ b/product_harmonized_system/views/product_category.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  © 2010-2016 Akretion (http://www.akretion.com/)
+  Copyright 2010-2016 Akretion (http://www.akretion.com/)
   @author Alexis de Lattre <alexis.delattre@akretion.com>
-  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). 
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 
 <odoo>
@@ -15,7 +15,7 @@
       <field name="arch" type="xml">
         <xpath expr="//group[@name='first']" position="after">
           <group name="hs_code" string="Import/Export Properties" colspan="2">
-            <field name="hs_code_id"/>
+            <field name="hs_code"/>
           </group>
         </xpath>
       </field>

--- a/product_harmonized_system/views/product_template.xml
+++ b/product_harmonized_system/views/product_template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  © 2010-2016 Akretion (http://www.akretion.com/)
+  Copyright 2010-2016 Akretion (http://www.akretion.com/)
   @author Alexis de Lattre <alexis.delattre@akretion.com>
   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
@@ -11,10 +11,9 @@
     <record id="product_template_form_view" model="ir.ui.view">
       <field name="name">hs_code.product.template.form</field>
       <field name="model">product.template</field>
-      <field name="inherit_id" ref="product.product_template_form_view" />
+      <field name="inherit_id" ref="delivery.product_template_hs_code" />
       <field name="arch" type="xml">
-        <field name="list_price" position="after">
-          <field name="hs_code_id" attrs="{'invisible': [('type', '=', 'service')]}"/>
+        <field name="hs_code" position="after">
           <field name="origin_country_id" attrs="{'invisible': [('type', '=', 'service')]}"/>
         </field>
       </field>


### PR DESCRIPTION
Hello,
In [odoo/delivery](https://github.com/odoo/odoo/blob/10.0/addons/delivery/views/product_template_view.xml#L10) you can find the hs_code field. It is also introduced by https://github.com/OCA/intrastat/blame/10.0/product_harmonized_system/views/product_template.xml#L17 in the product.template view.

The goal of this PR is to use the same name for this field in OCA and Odoo's base code source.