### PR TITLE
region attrs invisible

### DIFF
--- a/intrastat_product/__openerp__.py
+++ b/intrastat_product/__openerp__.py
@@ -1,30 +1,11 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Intrastat Product module for Odoo
-#    Copyright (C) 2011-2015 Akretion (http://www.akretion.com)
-#    Copyright (C) 2009-2015 Noviat (http://www.noviat.com)
-#    @author Alexis de Lattre <alexis.delattre@akretion.com>
-#    @author Luc de Meyer <info@noviat.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2011-2017 Akretion (http://www.akretion.com)
+# Copyright 2009-2017 Noviat
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     'name': 'Intrastat Product',
-    'version': '8.0.1.4.1',
+    'version': '8.0.1.5.0',
     'category': 'Intrastat',
     'license': 'AGPL-3',
     'summary': 'Base module for Intrastat Product',

--- a/intrastat_product/__openerp__.py
+++ b/intrastat_product/__openerp__.py
@@ -16,7 +16,7 @@
         'stock_picking_invoice_link',
         'sale_stock',
         'purchase',
-        ],
+    ],
     'conflicts': ['report_intrastat'],
     'data': [
         'views/hs_code.xml',

--- a/intrastat_product/models/account_invoice.py
+++ b/intrastat_product/models/account_invoice.py
@@ -43,6 +43,8 @@ class AccountInvoice(models.Model):
     src_dest_country_id = fields.Many2one(
         'res.country', string='Origin/Destination Country',
         ondelete='restrict')
+    src_dest_country_code = fields.Char(
+        related='company_id.country_id.code')
     src_dest_region_id = fields.Many2one(
         'intrastat.region', string='Origin/Destination Region',
         default=lambda self: self._default_src_dest_region_id(),

--- a/intrastat_product/models/account_invoice.py
+++ b/intrastat_product/models/account_invoice.py
@@ -1,28 +1,9 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Intrastat Product module for Odoo
-#    Copyright (C) 2011-2016 Akretion (http://www.akretion.com)
-#    Copyright (C) 2009-2016 Noviat (http://www.noviat.com)
-#    @author Alexis de Lattre <alexis.delattre@akretion.com>
-#    @author Luc de Meyer <info@noviat.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2011-2017 Akretion (http://www.akretion.com)
+# Copyright 2009-2017 Noviat
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import models, fields, api
+from openerp import api, fields, models
 
 
 class AccountInvoice(models.Model):
@@ -44,7 +25,7 @@ class AccountInvoice(models.Model):
         'res.country', string='Origin/Destination Country',
         ondelete='restrict')
     src_dest_country_code = fields.Char(
-        related='company_id.country_id.code')
+        related='company_id.country_id.code', readonly=True)
     src_dest_region_id = fields.Many2one(
         'intrastat.region', string='Origin/Destination Region',
         default=lambda self: self._default_src_dest_region_id(),

--- a/intrastat_product/models/account_invoice.py
+++ b/intrastat_product/models/account_invoice.py
@@ -24,7 +24,7 @@ class AccountInvoice(models.Model):
     src_dest_country_id = fields.Many2one(
         'res.country', string='Origin/Destination Country',
         ondelete='restrict')
-    src_dest_country_code = fields.Char(
+    company_country_code = fields.Char(
         related='company_id.country_id.code', readonly=True)
     src_dest_region_id = fields.Many2one(
         'intrastat.region', string='Origin/Destination Region',

--- a/intrastat_product/models/res_company.py
+++ b/intrastat_product/models/res_company.py
@@ -46,6 +46,8 @@ class ResCompany(models.Model):
     intrastat = fields.Char(
         string='Intrastat Declaration', store=True, readonly=True,
         compute='_compute_intrastat')
+    country_code = fields.Char(
+        related='country_id.code')
     intrastat_region_id = fields.Many2one(
         'intrastat.region',
         string='Default Intrastat Region')

--- a/intrastat_product/models/res_company.py
+++ b/intrastat_product/models/res_company.py
@@ -1,28 +1,9 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Intrastat Product module for Odoo
-#    Copyright (C) 2011-2015 Akretion (http://www.akretion.com)
-#    Copyright (C) 2009-2015 Noviat (http://www.noviat.com)
-#    @author Alexis de Lattre <alexis.delattre@akretion.com>
-#    @author Luc de Meyer <info@noviat.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2011-2017 Akretion (http://www.akretion.com)
+# Copyright 2009-2017 Noviat
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import models, fields, api
+from openerp import api, fields, models
 
 
 class ResCompany(models.Model):
@@ -47,7 +28,7 @@ class ResCompany(models.Model):
         string='Intrastat Declaration', store=True, readonly=True,
         compute='_compute_intrastat')
     country_code = fields.Char(
-        related='country_id.code')
+        related='country_id.code', readonly=True)
     intrastat_region_id = fields.Many2one(
         'intrastat.region',
         string='Default Intrastat Region')

--- a/intrastat_product/models/stock_warehouse.py
+++ b/intrastat_product/models/stock_warehouse.py
@@ -1,26 +1,8 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Odoo, Open Source Management Solution
-#
-#    Copyright (c) 2009-2015 Noviat nv/sa (www.noviat.com).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2009-2017 Noviat
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import models, fields, api
+from openerp import api, fields, models
 
 
 class StockWarehouse(models.Model):
@@ -30,7 +12,7 @@ class StockWarehouse(models.Model):
         'intrastat.region',
         string='Intrastat region')
     country_code = fields.Char(
-        related='company_id.country_id.code')
+        related='company_id.country_id.code', readonly=True)
 
 
 class StockLocation(models.Model):

--- a/intrastat_product/models/stock_warehouse.py
+++ b/intrastat_product/models/stock_warehouse.py
@@ -29,6 +29,8 @@ class StockWarehouse(models.Model):
     region_id = fields.Many2one(
         'intrastat.region',
         string='Intrastat region')
+    country_code = fields.Char(
+        related='company_id.country_id.code')
 
 
 class StockLocation(models.Model):

--- a/intrastat_product/views/account_invoice.xml
+++ b/intrastat_product/views/account_invoice.xml
@@ -18,9 +18,9 @@
                  attrs="{'invisible': [('intrastat', '!=', 'extended')]}"
                  widget="selection"/>
           <field name="src_dest_country_id" string="Destination Country"/>
-          <field name="src_dest_country_code" invisible="1"/>
+          <field name="company_country_code" invisible="1"/>
           <field name="src_dest_region_id" string="Origin/Destination Region"
-                 attrs="{'invisible': [('src_dest_country_code', 'not in', ['BE'])]}"/>
+                 attrs="{'invisible': [('company_country_code', 'not in', ['BE'])]}"/>
         </xpath>
         <xpath expr="//field[@name='invoice_line']//field[@name='account_id']" position="after">
           <field name="hs_code_id"/>
@@ -44,9 +44,9 @@
                  attrs="{'invisible': [('intrastat', '!=', 'extended')]}"
                  widget="selection"/>
           <field name="src_dest_country_id" string="Origin/Destination Country"/>
-          <field name="src_dest_country_code" invisible="1"/>
+          <field name="company_country_code" invisible="1"/>
           <field name="src_dest_region_id" string="Origin/Destination Region"
-                 attrs="{'invisible': [('src_dest_country_code', 'not in', ['BE'])]}"/>
+                 attrs="{'invisible': [('company_country_code', 'not in', ['BE'])]}"/>
         </xpath>
         <xpath expr="//field[@name='invoice_line']//field[@name='account_id']" position="after">
           <field name="hs_code_id"/>

--- a/intrastat_product/views/account_invoice.xml
+++ b/intrastat_product/views/account_invoice.xml
@@ -18,7 +18,9 @@
                  attrs="{'invisible': [('intrastat', '!=', 'extended')]}"
                  widget="selection"/>
           <field name="src_dest_country_id" string="Destination Country"/>
-          <field name="src_dest_region_id" string="Origin Region" invisible="1"/>
+          <field name="src_dest_country_code" invisible="1"/>
+          <field name="src_dest_region_id" string="Origin/Destination Region"
+                 attrs="{'invisible': [('src_dest_country_code', 'not in', ['BE'])]}"/>
         </xpath>
         <xpath expr="//field[@name='invoice_line']//field[@name='account_id']" position="after">
           <field name="hs_code_id"/>
@@ -42,7 +44,9 @@
                  attrs="{'invisible': [('intrastat', '!=', 'extended')]}"
                  widget="selection"/>
           <field name="src_dest_country_id" string="Origin/Destination Country"/>
-          <field name="src_dest_region_id" string="Origin/Destination Region" invisible="1"/>
+          <field name="src_dest_country_code" invisible="1"/>
+          <field name="src_dest_region_id" string="Origin/Destination Region"
+                 attrs="{'invisible': [('country_code', 'not in', ['BE'])]}"/>
         </xpath>
         <xpath expr="//field[@name='invoice_line']//field[@name='account_id']" position="after">
           <field name="hs_code_id"/>

--- a/intrastat_product/views/account_invoice.xml
+++ b/intrastat_product/views/account_invoice.xml
@@ -46,7 +46,7 @@
           <field name="src_dest_country_id" string="Origin/Destination Country"/>
           <field name="src_dest_country_code" invisible="1"/>
           <field name="src_dest_region_id" string="Origin/Destination Region"
-                 attrs="{'invisible': [('country_code', 'not in', ['BE'])]}"/>
+                 attrs="{'invisible': [('src_dest_country_code', 'not in', ['BE'])]}"/>
         </xpath>
         <xpath expr="//field[@name='invoice_line']//field[@name='account_id']" position="after">
           <field name="hs_code_id"/>

--- a/intrastat_product/views/res_company.xml
+++ b/intrastat_product/views/res_company.xml
@@ -15,7 +15,9 @@
           <field name="intrastat_transaction_out_refund"/>
           <field name="intrastat_transaction_in_invoice"/>
           <field name="intrastat_transaction_in_refund"/>
-          <field name="intrastat_region_id" domain="[('country_id','=', country_id)]" invisible="1"/>
+          <field name="country_code" invisible="1"/>
+          <field name="intrastat_region_id" domain="[('country_id','=', country_id)]"
+                 attrs="{'invisible': [('country_code', 'not in', ['BE'])]}"/>
           <field name="intrastat_transport_id"
                  attrs="{'required': [('intrastat', '=', 'extended')], 'invisible': [('intrastat', '!=', 'extended')]}"/>
           <field name="intrastat_incoterm_id" invisible="1"/>

--- a/intrastat_product/views/stock_warehouse.xml
+++ b/intrastat_product/views/stock_warehouse.xml
@@ -8,7 +8,8 @@
       <field name="inherit_id" ref="stock.view_warehouse"/>
       <field name="arch" type="xml">
         <xpath expr="//field[@name='partner_id']" position="after">
-          <field name="region_id"/>
+          <field name="country_code" invisible="1"/>
+          <field name="region_id" attrs="{'invisible': [('country_code', 'not in', ['BE'])]}"/>
         </xpath>
       </field>
     </record>


### PR DESCRIPTION
some localisation modules (e.g. Belgium) require the region field.
Other localisations also require the region concept for the intrastat declaration but this requirement is fulfilled via other means, e.g.
- France : departments
- Spain : states

This creates a confusing User Interfaces with region, department and state fields on several objects when running in a multi-company setup with multiple intrastat localisations.

This PR solves this by implementing the display/non-display logic of the country field to the 'intrastat_product' module whereby a list of country codes in the "attrs" attribute determines the visibility.