### PR TITLE
[10.0]Add hs_code_link

### DIFF
--- a/hs_code_link/README.rst
+++ b/hs_code_link/README.rst
@@ -1,0 +1,46 @@
+============
+HS Code Link
+============
+
+Odoo added a field char field `hs_code` in the delivery module.
+It results in a duplicate field from `product_harmonized_system` and it can be
+seen twice in the `product.template` form view.
+
+The goal of this module is to hide Odoo's field in the form and make it related
+to the OCA's one if it is used elsewhere.
+
+Installation
+============
+
+This module is set as auto_install if the following modules are installed:
+
+* product_harmonized_system
+* delivery
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Denis Leemann <denis.leemann@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/hs_code_link/__init__.py
+++ b/hs_code_link/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/hs_code_link/__manifest__.py
+++ b/hs_code_link/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "HS Code Link",
+    "version": "10.0.1.0.0",
+    "depends": [
+        'product_harmonized_system',
+        'delivery',
+    ],
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "website": "http://www.camptocamp.com",
+    "license": "AGPL-3",
+    "category": "Reporting",
+    "data": [
+        'views/product_views.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+}

--- a/hs_code_link/models/__init__.py
+++ b/hs_code_link/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import product

--- a/hs_code_link/models/product.py
+++ b/hs_code_link/models/product.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    hs_code = fields.Char(
+        related='hs_code_id.hs_code',
+        readonly=True,
+        store=True,
+    )

--- a/hs_code_link/views/product_views.xml
+++ b/hs_code_link/views/product_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+  <record id="view_template_hide_hs" model="ir.ui.view">
+    <field name="name">product.template.hs.hidden</field>
+    <field name="model">product.template</field>
+    <field name="inherit_id" ref="delivery.product_template_hs_code"/>
+    <field name="arch" type="xml">
+      <field name="hs_code" position="attributes">
+        <attribute name="invisible">True</attribute>
+      </field>
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
Odoo added a field char field `hs_code` in the delivery module.
It results in a duplicate field from `product_harmonized_system` and it can be
seen twice in the `product.template` form view.

The goal of this module is to hide Odoo's field in the form and make it related
to the OCA's one if it is used elsewhere.

This module is set as auto_install if the following modules are installed:

* product_harmonized_system
* delivery
