### PR TITLE
[REF] getting hs code should be done on the product.product

### DIFF
--- a/intrastat_product/models/account_invoice.py
+++ b/intrastat_product/models/account_invoice.py
@@ -121,7 +121,7 @@ class AccountInvoiceLine(models.Model):
 
         if product:
             product = self.env['product.product'].browse(product)
-            hs_code = product.product_tmpl_id.get_hs_code_recursively()
+            hs_code = product.get_hs_code_recursively()
             if hs_code:
                 res['value']['hs_code_id'] = hs_code.id
             else:

--- a/product_harmonized_system/models/product_template.py
+++ b/product_harmonized_system/models/product_template.py
@@ -39,6 +39,10 @@ class ProductTemplate(models.Model):
         help="Country of origin of the product i.e. product "
         "'made in ____'.")
 
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
     @api.multi
     def get_hs_code_recursively(self):
         self.ensure_one()


### PR DESCRIPTION
Getting hs code should be done on the product.product
Indeed in some really special case hscode can depend of the variant.
Moving the method to the product.product make it inheritable in custom module