### PR TITLE
[FIX] intrastat_product: state can be None

### DIFF
--- a/intrastat_product/__manifest__.py
+++ b/intrastat_product/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Intrastat Product',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'Intrastat',
     'license': 'AGPL-3',
     'summary': 'Base module for Intrastat Product',

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -177,6 +177,9 @@ class IntrastatProductDeclaration(models.Model):
     def _compute_company_country_code(self):
         for this in self:
             if this.company_id:
+                if not this.company_id.country_id:
+                    raise ValidationError(
+                        _("You must set company's country !"))
                 this.company_country_code = \
                     this.company_id.country_id.code.lower()
 


### PR DESCRIPTION
Company's country field is not required.
If country is not set, an error is raised.

cc @Tecnativa