### PR TITLE
[10.0][FIX] fix get hs code recursively

### DIFF
--- a/product_harmonized_system/models/product_category.py
+++ b/product_harmonized_system/models/product_category.py
@@ -26,5 +26,5 @@ class ProductCategory(models.Model):
         elif self.parent_id:
             res = self.parent_id.get_hs_code_recursively()
         else:
-            res = None
+            res = self.env['hs.code']
         return res

--- a/product_harmonized_system/models/product_template.py
+++ b/product_harmonized_system/models/product_template.py
@@ -25,11 +25,13 @@ class ProductTemplate(models.Model):
 
     @api.multi
     def get_hs_code_recursively(self):
-        self.ensure_one()
-        if self.hs_code_id:
-            res = self.hs_code_id
-        elif self.categ_id:
-            res = self.categ_id.get_hs_code_recursively()
+        res = self.env['hs.code']
+        if not self:
+            return res
         else:
-            res = None
-        return res
+            self.ensure_one()
+            if self.hs_code_id:
+                res = self.hs_code_id
+            elif self.categ_id:
+                res = self.categ_id.get_hs_code_recursively()
+            return res


### PR DESCRIPTION
The get_hs_code_recursively cannot be called from e.g. an invoice line without product_id because of the self.ensure_one().

The function also returns 'None' when no hs.code has been defined. Imho it is better to return an empty hs.code recordset in such cases.