### PR TITLE
[10.0][FIX] Several very important fixes

### DIFF
--- a/intrastat_product/data/intrastat_transport_mode.xml
+++ b/intrastat_product/data/intrastat_transport_mode.xml
@@ -30,7 +30,6 @@
       <field name="code">7</field>
       <field name="name">Fixed installations</field>
       <field name="description">Fixed transport installations (e.g. pipelines, high-tension cables)</field>
-      <field name="description"></field>
     </record>
     <record id="intrastat_transport_8" model="intrastat.transport_mode">
       <field name="code">8</field>

--- a/intrastat_product/models/account_invoice.py
+++ b/intrastat_product/models/account_invoice.py
@@ -22,12 +22,12 @@ class AccountInvoice(models.Model):
     src_dest_country_id = fields.Many2one(
         'res.country', string='Origin/Destination Country',
         compute='_compute_intrastat_country',
-        store=True,
+        store=True, compute_sudo=True,
         help="Destination country for dispatches. Origin country for "
         "arrivals.")
     intrastat_country = fields.Boolean(
         compute='_compute_intrastat_country',
-        store=True, string='Intrastat Country', readonly=True)
+        store=True, string='Intrastat Country', readonly=True, compute_sudo=True)
     src_dest_region_id = fields.Many2one(
         'intrastat.region', string='Origin/Destination Region',
         default=lambda self: self._default_src_dest_region_id(),
@@ -36,7 +36,7 @@ class AccountInvoice(models.Model):
         ondelete='restrict')
     intrastat = fields.Char(
         string='Intrastat Declaration',
-        related='company_id.intrastat', readonly=True)
+        related='company_id.intrastat', readonly=True, compute_sudo=True)
 
     @api.multi
     @api.depends('partner_shipping_id.country_id', 'partner_id.country_id')

--- a/intrastat_product/models/account_invoice.py
+++ b/intrastat_product/models/account_invoice.py
@@ -14,8 +14,7 @@ class AccountInvoice(models.Model):
     # Odoo v8 name: incoterm_id
     intrastat_transaction_id = fields.Many2one(
         'intrastat.transaction', string='Intrastat Transaction Type',
-        default=lambda self: self._default_intrastat_transaction_id(),
-        ondelete='restrict',
+        ondelete='restrict', track_visibility='onchange',
         help="Intrastat nature of transaction")
     intrastat_transport_id = fields.Many2one(
         'intrastat.transport_mode', string='Intrastat Transport Mode',
@@ -49,22 +48,6 @@ class AccountInvoice(models.Model):
                 country = inv.company_id.country_id
             inv.src_dest_country_id = country.id
             inv.intrastat_country = country.intrastat
-
-    @api.model
-    def _default_intrastat_transaction_id(self):
-        rco = self.env['res.company']
-        company = rco._company_default_get('account.invoice')
-        inv_type = self._context.get('type')
-        if inv_type == 'out_invoice':
-            return company.intrastat_transaction_out_invoice
-        elif inv_type == 'out_refund':
-            return company.intrastat_transaction_out_refund
-        elif inv_type == 'in_invoice':
-            return company.intrastat_transaction_in_invoice
-        elif inv_type == 'in_refund':
-            return company.intrastat_transaction_in_refund
-        else:
-            return self.env['intrastat.transaction']
 
     @api.model
     def _default_src_dest_region_id(self):

--- a/intrastat_product/models/account_invoice.py
+++ b/intrastat_product/models/account_invoice.py
@@ -26,8 +26,8 @@ class AccountInvoice(models.Model):
         help="Destination country for dispatches. Origin country for "
         "arrivals.")
     intrastat_country = fields.Boolean(
-        compute='_compute_intrastat_country',
-        store=True, string='Intrastat Country', readonly=True, compute_sudo=True)
+        compute='_compute_intrastat_country', string='Intrastat Country',
+        store=True, readonly=True, compute_sudo=True)
     src_dest_region_id = fields.Many2one(
         'intrastat.region', string='Origin/Destination Region',
         default=lambda self: self._default_src_dest_region_id(),

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -616,7 +616,7 @@ class IntrastatProductDeclaration(models.Model):
     @api.multi
     def action_gather(self):
         self.ensure_one()
-        self.message_post(_("Generate Lines from Invoices"))
+        self.message_post(body=_("Generate Lines from Invoices"))
         self._check_generate_lines()
         self._note = ''
         if (
@@ -683,7 +683,7 @@ class IntrastatProductDeclaration(models.Model):
         """ generate declaration lines """
         self.ensure_one()
         assert self.valid, 'Computation lines are not valid'
-        self.message_post(_("Generate Declaration Lines"))
+        self.message_post(body=_("Generate Declaration Lines"))
         # Delete existing declaration lines
         self.declaration_line_ids.unlink()
         # Regenerate declaration lines from computation lines
@@ -706,7 +706,7 @@ class IntrastatProductDeclaration(models.Model):
     def generate_xml(self):
         """ generate the INTRASTAT Declaration XML file """
         self.ensure_one()
-        self.message_post(_("Generate XML Declaration File"))
+        self.message_post(body=_("Generate XML Declaration File"))
         self._check_generate_xml()
         self._unlink_attachments()
         xml_string = self._generate_xml()

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -153,7 +153,7 @@ class IntrastatProductDeclaration(models.Model):
         '_get_reporting_level',
         string='Reporting Level')
     valid = fields.Boolean(
-        compute='_check_validity',
+        compute='_compute_check_validity',
         string='Valid')
 
     @api.model
@@ -193,7 +193,7 @@ class IntrastatProductDeclaration(models.Model):
 
     @api.multi
     @api.depends('month')
-    def _check_validity(self):
+    def _compute_check_validity(self):
         """ TO DO: logic based upon computation lines """
         for this in self:
             this.valid = True
@@ -750,7 +750,7 @@ class IntrastatProductComputationLine(models.Model):
         string='Reporting Level',
         readonly=True)
     valid = fields.Boolean(
-        compute='_check_validity',
+        compute='_compute_check_validity',
         string='Valid')
     invoice_line_id = fields.Many2one(
         'account.invoice.line', string='Invoice Line', readonly=True)
@@ -809,7 +809,7 @@ class IntrastatProductComputationLine(models.Model):
 
     @api.multi
     @api.depends('transport_id')
-    def _check_validity(self):
+    def _compute_check_validity(self):
         """ TO DO: logic based upon fields """
         for this in self:
             this.valid = True

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -365,7 +365,7 @@ class IntrastatProductDeclaration(models.Model):
                 [('invoice_lines', 'in', inv_line.id)])
             if po_lines:
                 if po_lines[0].move_ids:
-                    region = po_lines[0].move_ids[0].location_id\
+                    region = po_lines[0].move_ids[0].location_dest_id\
                         .get_intrastat_region()
         elif inv_type in ('out_invoice', 'out_refund'):
             so_lines = self.env['sale.order.line'].search(

--- a/intrastat_product/models/intrastat_transport_mode.py
+++ b/intrastat_product/models/intrastat_transport_mode.py
@@ -10,21 +10,19 @@ from odoo import models, fields, api
 class IntrastatTransportMode(models.Model):
     _name = 'intrastat.transport_mode'
     _description = "Intrastat Transport Mode"
-    _rec_name = 'display_name'
     _order = 'code'
 
-    display_name = fields.Char(
-        string='Display Name', compute='_display_name', store=True,
-        readonly=True)
     code = fields.Char(string='Code', required=True)
     name = fields.Char(string='Name', required=True, translate=True)
     description = fields.Char(string='Description', translate=True)
 
-    @api.multi
     @api.depends('name', 'code')
-    def _display_name(self):
+    def name_get(self):
+        res = []
         for this in self:
-            this.display_name = '%s. %s' % (this.code, this.name)
+            name = '%s. %s' % (this.code, this.name)
+            res.append((this.id, name))
+        return res
 
     _sql_constraints = [(
         'intrastat_transport_code_unique',


### PR DESCRIPTION
Here is the scenario of the bug:
1) create a customer invoice with "Intrastat Transaction Type" = False and validate it
2) click on the "Refund" button and follow the wizard to create a draft refund
3) In the draft refund created, "Intrastat Transaction Type" has the default value for customer invoices, instead of having the default value for customer refunds

Code analysis: when you look at the code of the refund wizard, you see that it doesn't set the 'type' in the context, so the value of 'type' in the context is still 'out_invoice', so the default value for "Intrastat Transaction Type" is the one of Customer Invoices.

For me, the solution is just to not put any default value for the field "Intrastat Transaction Type". The code that generate the transaction lines of the intrastat declaration will use the default value for invoices where the field ""Intrastat Transaction Type" is empty.