### PR TITLE
[10.0][FIX]reporting level

### DIFF
--- a/intrastat_product/__manifest__.py
+++ b/intrastat_product/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Intrastat Product',
-    'version': '10.0.1.2.1',
+    'version': '10.0.1.3.0',
     'category': 'Intrastat',
     'license': 'AGPL-3',
     'summary': 'Base module for Intrastat Product',

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -696,7 +696,7 @@ class IntrastatProductDeclaration(models.Model):
                 dl_group[hashcode] = [cl]
         ipdl = self.declaration_line_ids
         for cl_lines in dl_group.values():
-            vals = ipdl._prepare_declaration_line(cl_lines)
+            vals = ipdl._prepare_declaration_line(cl_lines, self)
             declaration_line = ipdl.create(vals)
             for cl in cl_lines:
                 cl.write({'declaration_line_id': declaration_line.id})
@@ -890,7 +890,8 @@ class IntrastatProductDeclarationLine(models.Model):
         help="Country of origin of the product i.e. product 'made in ____'")
 
     @api.model
-    def _prepare_grouped_fields(self, computation_line, fields_to_sum):
+    def _prepare_grouped_fields(self, computation_line, fields_to_sum,
+                                declaration):
         vals = {
             'src_dest_country_id': computation_line.src_dest_country_id.id,
             'intrastat_unit_id': computation_line.intrastat_unit_id.id,
@@ -915,10 +916,10 @@ class IntrastatProductDeclarationLine(models.Model):
         return fields_to_sum
 
     @api.model
-    def _prepare_declaration_line(self, computation_lines):
+    def _prepare_declaration_line(self, computation_lines, declaration):
         fields_to_sum = self._fields_to_sum()
         vals = self._prepare_grouped_fields(
-            computation_lines[0], fields_to_sum)
+            computation_lines[0], fields_to_sum, declaration)
         for computation_line in computation_lines:
             for field in fields_to_sum:
                 vals[field] += computation_line[field]

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -678,6 +678,51 @@ class IntrastatProductDeclaration(models.Model):
         hashcode = '-'.join([unicode(f) for f in hc_fields.itervalues()])
         return hashcode
 
+    @api.model
+    def _prepare_grouped_fields(self, computation_line, fields_to_sum):
+        vals = {
+            'src_dest_country_id': computation_line.src_dest_country_id.id,
+            'intrastat_unit_id': computation_line.intrastat_unit_id.id,
+            'hs_code_id': computation_line.hs_code_id.id,
+            'transaction_id': computation_line.transaction_id.id,
+            'transport_id': computation_line.transport_id.id,
+            'region_id': computation_line.region_id.id,
+            'parent_id': computation_line.parent_id.id,
+            'product_origin_country_id':
+            computation_line.product_origin_country_id.id,
+            'amount_company_currency': 0.0,
+            }
+        for field in fields_to_sum:
+            vals[field] = 0.0
+        return vals
+
+    def _fields_to_sum(self):
+        fields_to_sum = [
+            'weight',
+            'suppl_unit_qty',
+            ]
+        return fields_to_sum
+
+    @api.model
+    def _prepare_declaration_line(self, computation_lines):
+        fields_to_sum = self._fields_to_sum()
+        vals = self._prepare_grouped_fields(
+            computation_lines[0], fields_to_sum)
+        for computation_line in computation_lines:
+            for field in fields_to_sum:
+                vals[field] += computation_line[field]
+            vals['amount_company_currency'] += (
+                computation_line['amount_company_currency'] +
+                computation_line['amount_accessory_cost_company_currency'])
+        # round, otherwise odoo with truncate (6.7 -> 6... instead of 7 !)
+        for field in fields_to_sum:
+            vals[field] = int(round(vals[field]))
+        if not vals['weight']:
+            vals['weight'] = 1
+        vals['amount_company_currency'] = int(round(
+            vals['amount_company_currency']))
+        return vals
+
     @api.multi
     def generate_declaration(self):
         """ generate declaration lines """
@@ -696,7 +741,7 @@ class IntrastatProductDeclaration(models.Model):
                 dl_group[hashcode] = [cl]
         ipdl = self.declaration_line_ids
         for cl_lines in dl_group.values():
-            vals = ipdl._prepare_declaration_line(cl_lines, self)
+            vals = self._prepare_declaration_line(cl_lines)
             declaration_line = ipdl.create(vals)
             for cl in cl_lines:
                 cl.write({'declaration_line_id': declaration_line.id})
@@ -890,8 +935,12 @@ class IntrastatProductDeclarationLine(models.Model):
         help="Country of origin of the product i.e. product 'made in ____'")
 
     @api.model
-    def _prepare_grouped_fields(self, computation_line, fields_to_sum,
-                                declaration):
+    def _prepare_grouped_fields(self, computation_line, fields_to_sum):
+        """
+        This method is DEPRECATED.
+        You should use the _prepare_grouped_fields method on the
+        IntrastatProductDeclaration class.
+        """
         vals = {
             'src_dest_country_id': computation_line.src_dest_country_id.id,
             'intrastat_unit_id': computation_line.intrastat_unit_id.id,
@@ -909,6 +958,11 @@ class IntrastatProductDeclarationLine(models.Model):
         return vals
 
     def _fields_to_sum(self):
+        """
+        This method is DEPRECATED.
+        You should use the _fields_to_sum method on the
+        IntrastatProductDeclaration class.
+        """
         fields_to_sum = [
             'weight',
             'suppl_unit_qty',
@@ -916,10 +970,15 @@ class IntrastatProductDeclarationLine(models.Model):
         return fields_to_sum
 
     @api.model
-    def _prepare_declaration_line(self, computation_lines, declaration):
+    def _prepare_declaration_line(self, computation_lines):
+        """
+        This method is DEPRECATED.
+        You should use the _fields_to_sum method on the
+        IntrastatProductDeclaration class.
+        """
         fields_to_sum = self._fields_to_sum()
         vals = self._prepare_grouped_fields(
-            computation_lines[0], fields_to_sum, declaration)
+            computation_lines[0], fields_to_sum)
         for computation_line in computation_lines:
             for field in fields_to_sum:
                 vals[field] += computation_line[field]


### PR DESCRIPTION
The _prepare_grouped_fields method does not pass the declaration object. As a consequence the localisation methods cannot add logic based upon declaration fields to add extra data for the local declaration.

A concrete example:

In the Belgian l10n_be_intrastat_product module we need to add the incoterms to the declaration lines in case of an extended declaration (i.e. declaration.reporting_level == 'extended').
Since the declaration is not passed to the _prepare_grouped_fields method we cannot perform the check and hence the incoterms are not added.

This PR fixes this issue but the proposed fix requires also a change to the localisation modules in case the inherited module call one of the methods changed by this PR:
- _prepare_declaration_line
- _prepare_grouped_fields

Since the localisation modules are in other repos, a simultaneous commit requires manual attention (can be avoided with a less clean solution than this PR).
