### PR TITLE
[8.0][FIX] intrastat_common - remove check on EUR

### DIFF
--- a/intrastat_base/models/intrastat_common.py
+++ b/intrastat_base/models/intrastat_common.py
@@ -55,11 +55,6 @@ class IntrastatCommon(models.AbstractModel):
                 raise UserError(
                     _("The country is not set on the company '%s'.")
                     % company.name)
-            if company.currency_id.name != 'EUR':
-                raise UserError(
-                    _("The company currency must be 'EUR', but is currently "
-                      "'%s'.")
-                    % company.currency_id.name)
         return True
 
     @api.multi


### PR DESCRIPTION
EU countries are subject to Intrastat, also EU countries outside of the EU zone. 
As a consequence the check on company currency == EUR must be removed from this module (the right place are the localization modules).