### PR TITLE
[10.0][FIX] get_hs_code_recursively broken on declaration

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -521,8 +521,7 @@ class IntrastatProductDeclaration(models.Model):
                 if inv_line.hs_code_id:
                     hs_code = inv_line.hs_code_id
                 elif inv_line.product_id and self._is_product(inv_line):
-                    hs_code = inv_line.product_id.product_tmpl_id.\
-                        get_hs_code_recursively()
+                    hs_code = inv_line.product_id.get_hs_code_recursively()
                     if not hs_code:
                         note = "\n" + _(
                             "Missing H.S. code on product %s. "


### PR DESCRIPTION
The intrastat declaration is broken in case no hs code is present on invoice lines as a consequence of https://github.com/OCA/intrastat/commit/33a92dcc4becd1e13b64d029b1b2549a747bee5b.