### PR TITLE
[8.0] add 'type' field to lines views

### DIFF
--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -156,6 +156,7 @@
             </div>
             <field name="suppl_unit_qty"/>
             <field name="intrastat_unit_id"/>
+            <field name="type" invisible="1"/>
             <field name="reporting_level" invisible="1"/>
             <field name="transport_id"
               attrs="{'required': [('reporting_level', '=', 'extended')], 'invisible': [('reporting_level', '!=', 'extended')]}"/>
@@ -193,6 +194,7 @@
           <field name="region_id" invisible="1"/>
           <field name="product_origin_country_id" invisible="1" string="Product C/O"/>
           <field name="invoice_id"/>
+          <field name="type" invisible="1"/>
           <field name="reporting_level" invisible="1"/>
         </tree>
       </field>
@@ -220,6 +222,7 @@
             </div>
             <field name="suppl_unit_qty"/>
             <field name="intrastat_unit_id"/>
+            <field name="type" invisible="1"/>
             <field name="reporting_level" invisible="1"/>
             <field name="transport_id"
               attrs="{'required': [('reporting_level', '=', 'extended')], 'invisible': [('reporting_level', '!=', 'extended')]}"/>
@@ -248,6 +251,7 @@
           <field name="weight"/>
           <field name="suppl_unit_qty"/>
           <field name="intrastat_unit_id"/>
+          <field name="type" invisible="1"/>
           <field name="reporting_level" invisible="1"/>
           <field name="transport_id"
             attrs="{'required': [('reporting_level', '=', 'extended')], 'invisible': [('reporting_level', '!=', 'extended')]}"/>


### PR DESCRIPTION
The belgian 2019 declaration requires different fields for arrivals and dispatches declarations.
As a consequences it is required to have the 'type' field available in the lines views so that it can be used in the attrs.