### PR TITLE
[10.0] add 'type' field to lines views

### DIFF
--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -152,6 +152,7 @@
             </div>
             <field name="suppl_unit_qty"/>
             <field name="intrastat_unit_id"/>
+            <field name="type" invisible="1"/>
             <field name="reporting_level" invisible="1"/>
             <field name="transport_id"
               attrs="{'required': [('reporting_level', '=', 'extended')], 'invisible': [('reporting_level', '!=', 'extended')]}"/>
@@ -189,6 +190,7 @@
           <field name="region_id" invisible="1"/>
           <field name="product_origin_country_id" invisible="1" string="Product C/O"/>
           <field name="invoice_id"/>
+          <field name="type" invisible="1"/>
           <field name="reporting_level" invisible="1"/>
         </tree>
       </field>
@@ -216,6 +218,7 @@
             </div>
             <field name="suppl_unit_qty"/>
             <field name="intrastat_unit_id"/>
+            <field name="type" invisible="1"/>
             <field name="reporting_level" invisible="1"/>
             <field name="transport_id"
               attrs="{'required': [('reporting_level', '=', 'extended')], 'invisible': [('reporting_level', '!=', 'extended')]}"/>
@@ -244,6 +247,7 @@
           <field name="weight"/>
           <field name="suppl_unit_qty"/>
           <field name="intrastat_unit_id"/>
+          <field name="type" invisible="1"/>
           <field name="reporting_level" invisible="1"/>
           <field name="transport_id"
             attrs="{'required': [('reporting_level', '=', 'extended')], 'invisible': [('reporting_level', '!=', 'extended')]}"/>


### PR DESCRIPTION
Forward port of #60 
 
The belgian 2019 declaration requires different fields for arrivals and dispatches declarations.
As a consequences it is required to have the 'type' field available in the lines views so that it can be used in the attrs.