### PR TITLE
[10.0][FIX]pass declaration to xls template

### DIFF
--- a/intrastat_product/report/intrastat_product_report_xls.py
+++ b/intrastat_product/report/intrastat_product_report_xls.py
@@ -23,7 +23,7 @@ class IntrastatProductDeclarationXlsx(AbstractReportXlsx):
             self.env.cr, IR_TRANSLATION_NAME, 'report', lang, src) or src
         return val
 
-    def _get_template(self):
+    def _get_template(self, declaration):
 
         template = {
             'product': {
@@ -194,7 +194,7 @@ class IntrastatProductDeclarationXlsx(AbstractReportXlsx):
             },
         }
         template.update(
-            self.env['intrastat.product.declaration']._xls_template())
+            declaration._xls_template())
 
         return template
 
@@ -209,7 +209,7 @@ class IntrastatProductDeclarationXlsx(AbstractReportXlsx):
         return declaration
 
     def _get_ws_params(self, wb, data, declaration):
-        template = self._get_template()
+        template = self._get_template(declaration)
         if self.env.context.get('computation_lines'):
             wl = declaration._xls_computation_line_fields()
             report = 'computation'

--- a/intrastat_product/report/intrastat_product_report_xls.py
+++ b/intrastat_product/report/intrastat_product_report_xls.py
@@ -40,7 +40,7 @@ class IntrastatProductDeclarationXlsx(AbstractReportXlsx):
             'product_origin_country': {
                 'header': {
                     'type': 'string',
-                    'value': self._('Country of Origin of the Product'),
+                    'value': self._('Product C/O'),
                 },
                 'line': {
                     'type': 'string',

--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -54,7 +54,9 @@
                           context="{'computation_lines': 1}"/>
                 </header>
                 <group name="computation_lines">
-                  <field name="computation_line_ids" nolabel="1"/>
+                  <field name="computation_line_ids"
+                         context="{'type': type, 'reporting_level': reporting_level}"
+                         nolabel="1"/>
                 </group>
               </page>
               <page string="Declaration Lines">
@@ -63,7 +65,9 @@
                           context="{'declaration_lines': 1}"/>
                 </header>
                 <group name="declaration_lines">
-                  <field name="declaration_line_ids" nolabel="1"/>
+                  <field name="declaration_line_ids"
+                         context="{'type': type, 'reporting_level': reporting_level}"
+                         nolabel="1"/>
                 </group>
               </page>
               <page string="Notes">


### PR DESCRIPTION
pass declaration to xls template to allow localisation modules to tailor xls export based upon the declaration characteristics (e.g. different field in xls export for arrivals/dispatches)