### PR TITLE
[12.0][FIX] intrastat_base: related field editable in configuration

### DIFF
--- a/intrastat_base/README.rst
+++ b/intrastat_base/README.rst
@@ -63,6 +63,7 @@ Contributors
 * Alexis de Lattre, Akretion <alexis.delattre@akretion.com>
 * Luc De Meyer, Noviat <info@noviat.com>
 * Kumar Aberer, brain-tec AG <kumar.aberer@braintec-group.com>
+* Andrea Stirpe <a.stirpe@onestein.nl>
 
 Maintainer
 ----------

--- a/intrastat_base/__manifest__.py
+++ b/intrastat_base/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Intrastat Reporting Base',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'category': 'Intrastat',
     'license': 'AGPL-3',
     'summary': 'Base module for Intrastat reporting',

--- a/intrastat_base/models/res_config_settings.py
+++ b/intrastat_base/models/res_config_settings.py
@@ -9,4 +9,6 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     intrastat_remind_user_ids = fields.Many2many(
-        related='company_id.intrastat_remind_user_ids')
+        related='company_id.intrastat_remind_user_ids',
+        readonly=False,
+    )


### PR DESCRIPTION
Issue: in the configuration panel, it is not possible to configure field "_Users Receiving the Intrastat Reminder_" since it is not editable.

This PR makes the field "_Users Receiving the Intrastat Reminder_" editable.