### PR TITLE
[11.0][FIX] intrastat_product: translations in action field

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -148,9 +148,9 @@ class IntrastatProductDeclaration(models.Model):
     @api.model
     def _get_action(self):
         return [
-            ('replace', 'Replace'),
-            ('append', 'Append'),
-            ('nihil', 'Nihil')]
+            ('replace', _('Replace')),
+            ('append', _('Append')),
+            ('nihil', _('Nihil'))]
 
     @api.multi
     @api.depends('company_id')


### PR DESCRIPTION
Minor fix to enable translation in options for `action` field of `intrastat.product.declaration`.