### PR TITLE
[FIX] fix installation of demo data

### DIFF
--- a/intrastat_base/demo/intrastat_demo.xml
+++ b/intrastat_base/demo/intrastat_demo.xml
@@ -17,7 +17,7 @@
 
 <record id="shipping_costs_exclude" model="product.product">
     <field name="name">Shipping costs</field>
-    <field name="default_code">SHIP</field>
+    <field name="default_code">SHIP-INTRASTAT</field>
     <field name="type">service</field>
     <field name="categ_id" ref="product.product_category_all"/>
     <field name="list_price">30</field>


### PR DESCRIPTION
SHIP code is too common and conflict with "connector_ecommerce"
when "product_code_unique" is installed
Change the code as it's demo data.
If ok I will port the commit on other version @alexis-via 