### PR TITLE
FIX intrastat_base: update product shipping code

### DIFF
--- a/intrastat_base/demo/intrastat_demo.xml
+++ b/intrastat_base/demo/intrastat_demo.xml
@@ -18,7 +18,7 @@
 
 <record id="shipping_costs_exclude" model="product.product">
     <field name="name">Shipping costs</field>
-    <field name="default_code">SHIP</field>
+    <field name="default_code">SHIP_S</field>
     <field name="type">service</field>
     <field name="categ_id" ref="product.product_category_all"/>
     <field name="list_price">30</field>


### PR DESCRIPTION
## What's the problem
https://github.com/OCA/connector-ecommerce/blob/11.0/connector_ecommerce/data/ecommerce_data.xml#L10 and 
https://github.com/OCA/intrastat-extrastat/blob/12.0/intrastat_base/demo/intrastat_demo.xml#L21

conflict in combination with https://github.com/OCA/product-attribute/blob/12.0/product_code_unique/models/product.py#L10-L11

We want to avoid to have the same data than in connector_ecommerce
and risk constraint triggering on unique default_code in demo data and CI context.


## How to solve it ?

Rename ship product in this module.

SHIP_S is for SHIP_STAT

Please @alexis-via @luc-demeyer @hbrunn @florian-dacosta 
could check this PR ? Thanks