### PR TITLE
[FIX] intrastat_base: Fix display of field exclude_from_intrastat_if_present

### DIFF
--- a/intrastat_base/views/account_tax.xml
+++ b/intrastat_base/views/account_tax.xml
@@ -13,7 +13,7 @@
     <field name="model">account.tax</field>
     <field name="inherit_id" ref="account.view_tax_form"/>
     <field name="arch" type="xml">
-        <field name="active" position="before">
+        <field name="tag_ids" position="after">
             <field name="exclude_from_intrastat_if_present"/>
         </field>
     </field>


### PR DESCRIPTION
On the form view of account.tax, the "active" field is now a button, we have to update the inherit of the view.