### PR TITLE
[11.0][FIX] 11.0 add intrastat product

### DIFF
--- a/intrastat_product/README.rst
+++ b/intrastat_product/README.rst
@@ -87,6 +87,7 @@ Contributors
 
 * Alexis de Lattre, Akretion <alexis.delattre@akretion.com>
 * Luc De Meyer, Noviat <info@noviat.com>
+* Rodrigo Bonilla, FactorLibre <rodrigo.bonilla@factorlibre.com>
 
 Maintainer
 ----------


### PR DESCRIPTION
To whom it may concern,

From  _FactorLibre_ we have seen the need to modify the way we extract the product lines from the invoices before they are provided to Intrastat. Instead of extracting the product lines by searching the invoices one at a time, we have made it so the lines are obtained by searching all product lines within all invoices, in accordance to the following criteria:

If the declaration being generated is a “Declaration for Arrival”, only the lines that comply with the following criteria will be taken into account, since they imply a product entry:

- Lines from customer invoices in which the quantity is negative.
- Lines from customer rectification invoices in which the quantity is positive.
- Lines from suppliers invoices in which the quantity is positive.
- Lines from suppliers rectification invoices in which the quantity is negative.


If the declaration being generated is “Declaration for Dispatches”, only the lines that comply with the following criteria will be taken into account, since they imply a product departure:

- Lines from customer invoices in which the quantity is positive.
- Lines from customer rectification invoices in which the quantity is negative.
- Lines from suppliers invoices in which the quantity is negative.
- Lines from suppliers rectification invoices in which the quantity is positive.


The main reason for this modification is being able to have into account the invoices generated by a refund or the exchange of a product for another. This generates a rectification invoice that displays a line in which the quantity is negative and a line in which the quantity is positive. Our goal is to allow the system to distinguish which line corresponds to an entry and which to a departure when they’re added to the Intrastat report.

Thank you for your time.

Best regards.