### PR TITLE
[13.0]allow to encode intrastat transaction data on invoice line without product

### DIFF
--- a/intrastat_product/__manifest__.py
+++ b/intrastat_product/__manifest__.py
@@ -21,6 +21,8 @@
     ],
     "excludes": ["account_intrastat"],
     "data": [
+        "security/intrastat_security.xml",
+        "security/ir.model.access.csv",
         "views/hs_code.xml",
         "views/intrastat_region.xml",
         "views/intrastat_unit.xml",
@@ -31,8 +33,6 @@
         "views/account_move.xml",
         "views/sale_order.xml",
         "views/stock_warehouse.xml",
-        "security/intrastat_security.xml",
-        "security/ir.model.access.csv",
         "data/intrastat_transport_mode.xml",
         "data/intrastat_unit.xml",
     ],

--- a/intrastat_product/__manifest__.py
+++ b/intrastat_product/__manifest__.py
@@ -7,11 +7,11 @@
 
 {
     "name": "Intrastat Product",
-    "version": "13.0.1.0.3",
+    "version": "13.0.1.1.0",
     "category": "Intrastat",
     "license": "AGPL-3",
     "summary": "Base module for Intrastat Product",
-    "author": "brain-tec AG, Akretion, Noviat, " "Odoo Community Association (OCA)",
+    "author": "brain-tec AG, Akretion, Noviat, Odoo Community Association (OCA)",
     "depends": [
         "intrastat_base",
         "product_harmonized_system",

--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -99,6 +99,21 @@ class AccountMove(models.Model):
         return vals
 
 
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    hs_code_id = fields.Many2one(
+        comodel_name="hs.code", compute="_compute_hs_code_id", string="Intrastat Code",
+    )
+
+    def _compute_hs_code_id(self):
+        for rec in self:
+            intrastat_line = self.move_id.intrastat_line_ids.filtered(
+                lambda r: r.invoice_line_id == rec
+            )
+            rec.hs_code_id = intrastat_line.hs_code_id or rec.get_hs_code_recursively()
+
+
 class AccountMoveIntrastatLine(models.Model):
     _name = "account.move.intrastat.line"
     _description = "Intrastat declaration details"

--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -46,6 +46,11 @@ class AccountMove(models.Model):
     intrastat = fields.Char(
         string="Intrastat Declaration", related="company_id.intrastat"
     )
+    intrastat_line_ids = fields.One2many(
+        comodel_name="account.move.intrastat.line",
+        inverse_name="move_id",
+        string="Intrastat declaration details",
+    )
 
     @api.depends("partner_shipping_id.country_id", "partner_id.country_id")
     def _compute_intrastat_country(self):
@@ -60,23 +65,86 @@ class AccountMove(models.Model):
     def _default_src_dest_region_id(self):
         return self.env.company.intrastat_region_id
 
+    def compute_intrastat_lines(self):
+        """
+        Compute the Intrastat Lines so that they can be modified
+        when encoding the Customer/Supplier Invoice.
+        """
+        self.mapped("intrastat_line_ids").unlink()
+        for inv in self:
+            if inv.type not in ("out_invoice", "out_refund", "in_invoice", "in_refund"):
+                continue
+            line_vals = []
+            for line in inv.invoice_line_ids:
+                vals = self._get_intrastat_line_vals(line)
+                if vals:
+                    line_vals.append(vals)
+            if line_vals:
+                inv.intrastat_line_ids = [(0, 0, x) for x in line_vals]
 
-class AccountMoveLine(models.Model):
-    _inherit = "account.move.line"
+    def _get_intrastat_line_vals(self, line):
+        vals = {}
+        if self.env["intrastat.product.declaration"]._is_product(line):
+            hs_code = line.product_id.get_hs_code_recursively()
+            if not hs_code:
+                return vals
+            vals.update(
+                {
+                    "invoice_line_id": line.id,
+                    "hs_code_id": hs_code.id,
+                    "transaction_weight": int(line.product_id.weight * line.quantity),
+                    "product_origin_country_id": line.product_id.origin_country_id.id,
+                }
+            )
+        return vals
 
-    hs_code_id = fields.Many2one(
-        comodel_name="hs.code", string="Intrastat Code", ondelete="restrict"
+
+class AccountMoveIntrastatLine(models.Model):
+    _name = "account.move.intrastat.line"
+    _description = "Intrastat declaration details"
+    _order = "sequence"
+
+    move_id = fields.Many2one(
+        comodel_name="account.move",
+        string="Invoice",
+        ondelete="cascade",
+        required=True,
     )
-    weight = fields.Integer(string="Weight", help="Net weight in Kg")
+    invoice_line_id = fields.Many2one(
+        comodel_name="account.move.line",
+        string="Invoice Line",
+        ondelete="cascade",
+        required=True,
+    )
+    sequence = fields.Integer(related="invoice_line_id.sequence", store=True)
+    product_id = fields.Many2one(
+        comodel_name="product.product",
+        string="Product",
+        related="invoice_line_id.product_id",
+    )
+    quantity = fields.Float(related="invoice_line_id.quantity")
+    hs_code_id = fields.Many2one(
+        comodel_name="hs.code",
+        string="Intrastat Code",
+        ondelete="restrict",
+        required=True,
+    )
+    transaction_weight = fields.Integer(
+        help="Transaction weight in Kg: Quantity x Product Weight"
+    )
     product_origin_country_id = fields.Many2one(
         comodel_name="res.country",
         string="Country of Origin",
         help="Country of origin of the product i.e. product " "'made in ____'.",
     )
 
-    @api.onchange("product_id")
-    def intrastat_product_id_change(self):
-        if self.product_id:
-            self.hs_code_id = self.product_id.get_hs_code_recursively()
-            self.product_origin_country_id = self.product_id.origin_country_id
-            self.weight = self.product_id.weight
+    @api.onchange("invoice_line_id")
+    def _onchange_move_id(self):
+        moves = self.mapped("move_id")
+        dom = [
+            ("exclude_from_invoice_tab", "=", False),
+            ("display_type", "=", False),
+            ("id", "in", moves.mapped("invoice_line_ids").ids),
+            ("id", "not in", moves.mapped("intrastat_line_ids.invoice_line_id").ids),
+        ]
+        return {"domain": {"invoice_line_id": dom}}

--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -67,9 +67,16 @@ class AccountMoveLine(models.Model):
     hs_code_id = fields.Many2one(
         comodel_name="hs.code", string="Intrastat Code", ondelete="restrict"
     )
+    weight = fields.Integer(string="Weight", help="Net weight in Kg")
+    product_origin_country_id = fields.Many2one(
+        comodel_name="res.country",
+        string="Country of Origin",
+        help="Country of origin of the product i.e. product " "'made in ____'.",
+    )
 
     @api.onchange("product_id")
     def intrastat_product_id_change(self):
         if self.product_id:
-            hs_code = self.product_id.get_hs_code_recursively()
-            self.hs_code_id = hs_code and hs_code.id or False
+            self.hs_code_id = self.product_id.get_hs_code_recursively()
+            self.product_origin_country_id = self.product_id.origin_country_id
+            self.weight = self.product_id.weight

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -449,9 +449,7 @@ class IntrastatProductDeclaration(models.Model):
         return incoterm
 
     def _get_product_origin_country(self, inv_line):
-        return (
-            inv_line.product_origin_country_id or inv_line.product_id.origin_country_id
-        )
+        return inv_line.product_id.origin_country_id
 
     def _update_computation_line_vals(self, inv_line, line_vals):
         """ placeholder for localization modules """

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -272,6 +272,20 @@ class IntrastatProductDeclaration(models.Model):
         pce_uom = self._get_uom_refs("pce_uom")
         weight = suppl_unit_qty = 0.0
 
+        if not product:
+            weight = inv_line.weight
+            if not weight:
+                note = "\n" + _(
+                    "Missing weight on invoice %s, line with intrastat code %s."
+                ) % (inv_line.move_id.name, inv_line.hs_code_id.local_code)
+                note += "\n" + _(
+                    "Please correct the product record and regenerate "
+                    "the lines or adjust the impacted lines manually"
+                )
+                self._note += note
+                return weight, suppl_unit_qty
+            return weight, suppl_unit_qty
+
         if not source_uom:
             note = "\n" + _(
                 "Missing unit of measure on the line with %d "
@@ -435,7 +449,9 @@ class IntrastatProductDeclaration(models.Model):
         return incoterm
 
     def _get_product_origin_country(self, inv_line):
-        return inv_line.product_id.origin_country_id
+        return (
+            inv_line.product_origin_country_id or inv_line.product_id.origin_country_id
+        )
 
     def _update_computation_line_vals(self, inv_line, line_vals):
         """ placeholder for localization modules """

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -261,10 +261,9 @@ class IntrastatProductDeclaration(models.Model):
                 return company.intrastat_transaction_in_refund
 
     def _get_weight_and_supplunits(self, inv_line, hs_code, weight=None):
-        # TODO: refactor
+        line_nbr = self._line_nbr
         line_qty = inv_line.quantity
         product = inv_line.product_id
-        invoice = inv_line.move_id
         intrastat_unit_id = hs_code.intrastat_unit_id
         source_uom = inv_line.product_uom_id
         weight_uom_categ = self._get_uom_refs("weight_uom_categ")
@@ -276,49 +275,34 @@ class IntrastatProductDeclaration(models.Model):
             weight = 0.0
 
         if not source_uom:
-            note = "\n" + _(
-                "Missing unit of measure on the line with %d "
-                "product '%s' on invoice '%s'."
-            ) % (line_qty, product.name_get()[0][1], invoice.name)
-            note += "\n" + _("Please adjust this line manually.")
-            self._note += note
+            line_notes = [_("Missing unit of measure.")]
+            self._note += self._format_line_note(inv_line, line_nbr, line_notes)
             return weight, suppl_unit_qty
 
         if intrastat_unit_id:
             target_uom = intrastat_unit_id.uom_id
             if not target_uom:
-                note = (
-                    "\n"
-                    + _(
+                line_notes = [
+                    _("Intrastat Code %s:") % hs_code.display_name,
+                    _(
                         "Conversion from Intrastat Supplementary Unit '%s' to "
                         "Unit of Measure is not implemented yet."
                     )
-                    % intrastat_unit_id.name
-                )
-                note += (
-                    "\n"
-                    + _(
-                        "Please correct the Intrastat Supplementary Unit "
-                        "settings and regenerate the lines or adjust the lines "
-                        "with Intrastat Code '%s' manually"
-                    )
-                    % hs_code.display_name
-                )
-                self._note += note
+                    % intrastat_unit_id.name,
+                ]
+                self._note += self._format_line_note(inv_line, line_nbr, line_notes)
                 return weight, suppl_unit_qty
             if target_uom.category_id == source_uom.category_id:
                 suppl_unit_qty = source_uom._compute_quantity(line_qty, target_uom)
             else:
-                note = "\n" + _(
-                    "Conversion from unit of measure '%s' to '%s' "
-                    "is not implemented yet."
-                ) % (source_uom.name, target_uom.name)
-                note += "\n" + _(
-                    "Please correct the unit of measure settings and "
-                    "regenerate the lines or adjust the impacted "
-                    "lines manually"
-                )
-                self._note += note
+                line_notes = [
+                    _(
+                        "Conversion from unit of measure '%s' to '%s' "
+                        "is not implemented yet."
+                    )
+                    % (source_uom.name, target_uom.name)
+                ]
+                self._note += self._format_line_note(inv_line, line_nbr, line_notes)
                 return weight, suppl_unit_qty
 
         if weight:
@@ -330,11 +314,10 @@ class IntrastatProductDeclaration(models.Model):
             weight = source_uom._compute_quantity(line_qty, kg_uom)
         elif source_uom.category_id == pce_uom_categ:
             if not product.weight:  # re-create weight_net ?
-                note = (
-                    "\n" + _("Missing weight on product %s.") % product.name_get()[0][1]
-                )
-                note += " " + _("This product is present in invoice %s.") % invoice.name
-                self._note += note
+                line_notes = [
+                    _("Missing weight on product %s.") % product.name_get()[0][1]
+                ]
+                self._note += self._format_line_note(inv_line, line_nbr, line_notes)
                 return weight, suppl_unit_qty
             if source_uom == pce_uom:
                 weight = product.weight * line_qty  # product.weight_net
@@ -346,16 +329,14 @@ class IntrastatProductDeclaration(models.Model):
                     line_qty, pce_uom
                 )
         else:
-            note = "\n" + _(
-                "Conversion from unit of measure '%s' to 'Kg' "
-                "is not implemented yet. It is needed for product '%s'."
-            ) % (source_uom.name, product.name_get()[0][1])
-            note += "\n" + _(
-                "Please correct the unit of measure settings and "
-                "regenerate the lines or adjust the impacted lines "
-                "manually"
-            )
-            self._note += note
+            line_notes = [
+                _(
+                    "Conversion from unit of measure '%s' to 'Kg' "
+                    "is not implemented yet. It is needed for product '%s'."
+                )
+                % (source_uom.name, product.name_get()[0][1])
+            ]
+            self._note += self._format_line_note(inv_line, line_nbr, line_notes)
             return weight, suppl_unit_qty
 
         return weight, suppl_unit_qty
@@ -514,6 +495,15 @@ class IntrastatProductDeclaration(models.Model):
         """ placeholder for localization modules """
         pass
 
+    def _format_line_note(self, line, line_nbr, line_notes):
+        indent = 8 * " "
+        note = _("Invoice %s, line %s") % (line.move_id.name, line_nbr)
+        note += ":\n"
+        for line_note in line_notes:
+            note += indent + line_note
+            note += "\n"
+        return note
+
     def _gather_invoices(self):
 
         lines = []
@@ -521,7 +511,8 @@ class IntrastatProductDeclaration(models.Model):
 
         self._gather_invoices_init()
         domain = self._prepare_invoice_domain()
-        invoices = self.env["account.move"].search(domain)
+        order = "journal_id, name"
+        invoices = self.env["account.move"].search(domain, order=order)
 
         for invoice in invoices:
 
@@ -529,7 +520,8 @@ class IntrastatProductDeclaration(models.Model):
             total_inv_accessory_costs_cc = 0.0  # in company currency
             total_inv_product_cc = 0.0  # in company currency
             total_inv_weight = 0.0
-            for inv_line in invoice.invoice_line_ids:
+            for line_nbr, inv_line in enumerate(invoice.invoice_line_ids, start=1):
+                self._line_nbr = line_nbr
                 inv_intrastat_line = invoice.intrastat_line_ids.filtered(
                     lambda r: r.invoice_line_id == inv_line
                 )
@@ -582,19 +574,18 @@ class IntrastatProductDeclaration(models.Model):
                 elif inv_line.product_id and self._is_product(inv_line):
                     hs_code = inv_line.product_id.get_hs_code_recursively()
                     if not hs_code:
-                        note = "\n" + _(
-                            "Missing H.S. code on product %s. "
-                            "This product is present in invoice %s."
-                        ) % (
-                            inv_line.product_id.name_get()[0][1],
-                            inv_line.move_id.name,
+                        line_notes = [
+                            _("Missing Intrastat Code on product %s. ")
+                            % (inv_line.product_id.name_get()[0][1])
+                        ]
+                        self._note += self._format_line_note(
+                            inv_line, line_nbr, line_notes
                         )
-                        self._note += note
                         continue
                 else:
                     _logger.info(
                         "Skipping invoice line %s qty %s "
-                        "of invoice %s. Reason: no product nor hs_code"
+                        "of invoice %s. Reason: no product nor Intrastat Code"
                         % (inv_line.name, inv_line.quantity, invoice.name)
                     )
                     continue

--- a/intrastat_product/readme/CONFIGURE.rst
+++ b/intrastat_product/readme/CONFIGURE.rst
@@ -1,0 +1,14 @@
+By default the intrastat declaration is generated based upon the product record master data.
+Hence unexpected results may occur in case this master data is not accurate,
+e.g. wrong or missing weight, country of origin, ...
+
+|
+
+This can be corrected by changing the appropriate fields when analysing the intrastat declaration
+but this can be challenging in case of large transaction volumes and especially in the specific use
+case where the product weight cannot be encoded correctly on the product records (e.g. products with variable weight).
+
+|
+
+It is possible to allow encoding the intrastat transaction details on the purchase/sale invoice
+via the "intrastat_product.group_invoice_intrastat_transaction_detail" usability group.

--- a/intrastat_product/readme/CONFIGURE.rst
+++ b/intrastat_product/readme/CONFIGURE.rst
@@ -1,0 +1,15 @@
+By default the intrastat declaration is generated based upon the product record master data.
+Hence unexpected results may occur in case this master data is not accurate,
+e.g. wrong or missing weight, country of origin, ...
+
+|
+
+This can be corrected by changing the appropriate fields when analysing the intrastat declaration
+but this can be challenging in case of large transaction volumes and especially in the specific use
+case where the product weight cannot be encoded correctly on the product records (e.g. products with variable weight).
+
+|
+
+It is possible to allow encoding the intrastat transaction details on the purchase/sale invoice
+via the "intrastat_product.group_invoice_intrastat_transaction_detail" usability group.
+

--- a/intrastat_product/security/intrastat_security.xml
+++ b/intrastat_product/security/intrastat_security.xml
@@ -1,24 +1,35 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo noupdate="1">
-    <record id="intrastat_transaction_company_rule" model="ir.rule">
-        <field name="name">Intrastat Transaction Company rule</field>
-        <field name="model_id" ref="model_intrastat_transaction" />
-        <field
-            name="domain_force"
-        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
-    </record>
-    <record id="intrastat_region_company_rule" model="ir.rule">
-        <field name="name">Intrastat Region Company rule</field>
-        <field name="model_id" ref="model_intrastat_region" />
-        <field
-            name="domain_force"
-        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
-    </record>
-    <record id="intrastat_product_declaration_company_rule" model="ir.rule">
-        <field name="name">Intrastat Product Declaration Company rule</field>
-        <field name="model_id" ref="model_intrastat_product_declaration" />
-        <field
-            name="domain_force"
-        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
-    </record>
+<odoo>
+    <data noupdate="0">
+        <record id="group_invoice_intrastat_transaction_details" model="res.groups">
+            <field name="name">Invoice Intrastat Transaction Details</field>
+            <field
+                name="comment"
+            >Allow to encode Intrastat Transaction Details on Invoices</field>
+            <field name="category_id" ref="base.module_category_hidden" />
+        </record>
+    </data>
+    <data noupdate="1">
+        <record id="intrastat_transaction_company_rule" model="ir.rule">
+            <field name="name">Intrastat Transaction Company rule</field>
+            <field name="model_id" ref="model_intrastat_transaction" />
+            <field
+                name="domain_force"
+            >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        </record>
+        <record id="intrastat_region_company_rule" model="ir.rule">
+            <field name="name">Intrastat Region Company rule</field>
+            <field name="model_id" ref="model_intrastat_region" />
+            <field
+                name="domain_force"
+            >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        </record>
+        <record id="intrastat_product_declaration_company_rule" model="ir.rule">
+            <field name="name">Intrastat Product Declaration Company rule</field>
+            <field name="model_id" ref="model_intrastat_product_declaration" />
+            <field
+                name="domain_force"
+            >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        </record>
+    </data>
 </odoo>

--- a/intrastat_product/security/ir.model.access.csv
+++ b/intrastat_product/security/ir.model.access.csv
@@ -8,6 +8,7 @@ access_intrastat_transport_mode_full,Full access on Intrastat Transport Modes to
 access_intrastat_region_read,Read access on Intrastat Regions,model_intrastat_region,,1,0,0,0
 access_intrastat_region_full,Full access on Intrastat Regions,model_intrastat_region,account.group_account_manager,1,1,1,1
 access_hs_code_financial_mgr_full,Full access on H.S. Code to financial mgr,product_harmonized_system.model_hs_code,account.group_account_manager,1,1,1,1
+access_account_move_intrastat_line,Full access on Invoice Intrastat Lines,model_account_move_intrastat_line,account.group_account_invoice,1,1,1,1
 access_intrastat_product_declaration,Full access on Intrastat Product Declarations to Accountant,model_intrastat_product_declaration,account.group_account_user,1,1,1,1
 access_intrastat_product_computation_line,Full access on Intrastat Product Computation Lines to Accountant,model_intrastat_product_computation_line,account.group_account_user,1,1,1,1
 access_intrastat_product_declaration_line,Full access on Intrastat Product Declaration Lines to Accountant,model_intrastat_product_declaration_line,account.group_account_user,1,1,1,1

--- a/intrastat_product/views/account_move.xml
+++ b/intrastat_product/views/account_move.xml
@@ -24,12 +24,16 @@
                 position="after"
             >
                 <field name="hs_code_id" optional="hide" />
+                <field name="weight" optional="hide" />
+                <field name="product_origin_country_id" optional="hide" />
             </xpath>
             <xpath
                 expr="//field[@name='line_ids']//field[@name='account_id']"
                 position="after"
             >
                 <field name="hs_code_id" optional="hide" />
+                <field name="weight" optional="hide" />
+                <field name="product_origin_country_id" optional="hide" />
             </xpath>
         </field>
     </record>

--- a/intrastat_product/views/account_move.xml
+++ b/intrastat_product/views/account_move.xml
@@ -44,6 +44,7 @@
                             />
                             <field name="product_id" />
                             <field name="quantity" />
+                            <field name="transaction_suppl_unit_qty" />
                             <field name="hs_code_id" />
                             <field name="transaction_weight" />
                             <field

--- a/intrastat_product/views/account_move.xml
+++ b/intrastat_product/views/account_move.xml
@@ -19,22 +19,40 @@
                 <field name="src_dest_country_id" string="Destination Country" />
                 <field name="src_dest_region_id" string="Origin Region" invisible="1" />
             </xpath>
-            <xpath
-                expr="//field[@name='invoice_line_ids']//field[@name='account_id']"
-                position="after"
-            >
-                <field name="hs_code_id" optional="hide" />
-                <field name="weight" optional="hide" />
-                <field name="product_origin_country_id" optional="hide" />
-            </xpath>
-            <xpath
-                expr="//field[@name='line_ids']//field[@name='account_id']"
-                position="after"
-            >
-                <field name="hs_code_id" optional="hide" />
-                <field name="weight" optional="hide" />
-                <field name="product_origin_country_id" optional="hide" />
-            </xpath>
+            <page id="invoice_tab" position="after">
+                <page
+                    id="intrastat_lines"
+                    string="Intrastat transaction details"
+                    groups="intrastat_product.group_invoice_intrastat_transaction_details"
+                >
+                    <div>
+                        <button
+                            type="object"
+                            name="compute_intrastat_lines"
+                            string="Compute"
+                            help="(Re)compute the intrastat transaction details from the product master data."
+                            icon="fa-gears"
+                        />
+                    </div>
+                    <field name="intrastat_line_ids">
+                        <tree editable="bottom">
+                            <field
+                                name="invoice_line_id"
+                                domain="[('exclude_from_invoice_tab', '=', False), ('move_id', '=', parent.id), ('display_type', '=', False)]"
+                                options="{'no_create': True, 'no_open': True}"
+                            />
+                            <field name="product_id" />
+                            <field name="quantity" />
+                            <field name="hs_code_id" />
+                            <field name="transaction_weight" />
+                            <field
+                                name="product_origin_country_id"
+                                options="{'no_create': True, 'no_open': True}"
+                            />
+                        </tree>
+                    </field>
+                </page>
+            </page>
         </field>
     </record>
 </odoo>

--- a/intrastat_product/views/account_move.xml
+++ b/intrastat_product/views/account_move.xml
@@ -24,6 +24,7 @@
                     id="intrastat_lines"
                     string="Intrastat transaction details"
                     groups="intrastat_product.group_invoice_intrastat_transaction_details"
+                    attrs="{'invisible': [('type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'))]}"
                 >
                     <div>
                         <button


### PR DESCRIPTION
We get a stack trace on the intrastat report when entering an invoice line with an intrastat code but without product code.
This PR fixes this issue and allows at the same the users to add/modify the weight and the country of origin on the invoice line.
This use case is common when e.g. receiving a supplier invoice with intrastat codes and weight.
Creating a product record for a on-time purchase doesn't make a lot of sense.
Some companies also trade goods where the weight in different per transaction, this is now also fixed.