### PR TITLE
FIX add "rec_name" to allow import-compatible export

### DIFF
--- a/intrastat_product/models/intrastat_transaction.py
+++ b/intrastat_product/models/intrastat_transaction.py
@@ -18,7 +18,7 @@ class IntrastatTransaction(models.Model):
             "Code must be unique.",
         )
     ]
-    
+
     code = fields.Char(string="Code", required=True)
     description = fields.Text(string="Description")
     company_id = fields.Many2one(

--- a/intrastat_product/models/intrastat_transaction.py
+++ b/intrastat_product/models/intrastat_transaction.py
@@ -10,6 +10,7 @@ class IntrastatTransaction(models.Model):
     _name = "intrastat.transaction"
     _description = "Intrastat Transaction"
     _order = "code"
+    _rec_name = "code"
     _sql_constraints = [
         (
             "intrastat_transaction_code_unique",
@@ -17,7 +18,7 @@ class IntrastatTransaction(models.Model):
             "Code must be unique.",
         )
     ]
-
+    
     code = fields.Char(string="Code", required=True)
     description = fields.Text(string="Description")
     company_id = fields.Many2one(


### PR DESCRIPTION
without `rec_name`, we cannot export invoices with the box `I want to update data (import-compatible export)` because of the following error :
```
Odoo Server Error
Traceback (most recent call last):
  File "/odoo/src/odoo/http.py", line 624, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/odoo/src/odoo/http.py", line 310, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/odoo/src/odoo/tools/pycompat.py", line 14, in reraise
    raise value
  File "/odoo/src/odoo/http.py", line 669, in dispatch
    result = self._call_function(**self.params)
  File "/odoo/src/odoo/http.py", line 350, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/odoo/src/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/odoo/src/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/odoo/src/odoo/http.py", line 915, in __call__
    return self.method(*args, **kw)
  File "/odoo/src/odoo/http.py", line 515, in response_wrap
    response = f(*args, **kw)
  File "/odoo/src/addons/web/controllers/main.py", line 1684, in get_fields
    fields = {'id': fields['id'], rec_name: fields[rec_name]}
KeyError: None
```