### PR TITLE
[14.0][FIX] intrastat_product: Missed changes in migration

### DIFF
--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -65,7 +65,12 @@ class AccountMove(models.Model):
         """
         self.mapped("intrastat_line_ids").unlink()
         for inv in self:
-            if inv.type not in ("out_invoice", "out_refund", "in_invoice", "in_refund"):
+            if inv.move_type not in (
+                "out_invoice",
+                "out_refund",
+                "in_invoice",
+                "in_refund",
+            ):
                 continue
             line_vals = []
             for line in inv.invoice_line_ids:
@@ -77,12 +82,16 @@ class AccountMove(models.Model):
 
     def _get_intrastat_line_vals(self, line):
         vals = {}
+        notedict = {
+            "note": "",
+            "line_nbr": 0,
+        }
         decl_model = self.env["intrastat.product.declaration"]
         if decl_model._is_product(line):
             hs_code = line.product_id.get_hs_code_recursively()
             if not hs_code:
                 return vals
-            weight, qty = decl_model._get_weight_and_supplunits(line, hs_code)
+            weight, qty = decl_model._get_weight_and_supplunits(line, hs_code, notedict)
             vals.update(
                 {
                     "invoice_line_id": line.id,

--- a/intrastat_product/readme/USAGE.rst
+++ b/intrastat_product/readme/USAGE.rst
@@ -31,3 +31,9 @@ and adapt the code for the specific needs of your country.
 * XML Files: Menu, Action, Views
 
   Cf. l10n_be_istrastat_product as example, replace "be" by your Country Code.
+
+**Other functionality added by this module:**
+
+* Compute the Intrastat Lines in an invoice.
+  For this, your user needs to be in the "Technical / Invoice Intrastat Transaction Details" group.
+  Go to the "Intrastat transaction details" tab and press **Compute**


### PR DESCRIPTION
Change back from `invoice.type` to `invoice.move_type`
Update method signature and calls after the refactor in "intrastat.product.declaration"
Add some docs to explain the functionality that leads to this part of the code.

@Tecnativa
TT28080

ping @pedrobaeza @victoralmau 