### PR TITLE
[11.0][MIG] intrastat_product: add migration script

### DIFF
--- a/intrastat_product/migrations/11.0.1.0.0/post-migration.py
+++ b/intrastat_product/migrations/11.0.1.0.0/post-migration.py
@@ -1,0 +1,18 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2021 ForgeFlow <http://www.forgeflow.com>
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+def update_intrastat_product_declaration_year(env):
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE intrastat_product_declaration
+        SET year = {integer_year} || ''
+        """.format(integer_year=openupgrade.get_legacy_name("year"))
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    update_intrastat_product_declaration_year(env)

--- a/intrastat_product/migrations/11.0.1.0.0/pre-migration.py
+++ b/intrastat_product/migrations/11.0.1.0.0/pre-migration.py
@@ -1,0 +1,12 @@
+# Copyright 2021 ForgeFlow <http://www.forgeflow.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+_column_renames = {
+    "intrastat_product_declaration": [("year", None)],
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, _column_renames)


### PR DESCRIPTION
Field `year` was changed from `integer` to `char` in v11 migration, and nobody noticed it needed migration script.