### PR TITLE
[14.0][FIX] intrastat_product: don't force wrong domain in moves

### DIFF
--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -16,6 +16,7 @@ class AccountMove(models.Model):
         tracking=True,
         check_company=True,
         help="Intrastat nature of transaction",
+        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
     )
     intrastat_transport_id = fields.Many2one(
         comodel_name="intrastat.transport_mode",

--- a/intrastat_product/views/account_move.xml
+++ b/intrastat_product/views/account_move.xml
@@ -9,10 +9,7 @@
                 expr="//page[@name='other_info']//field[@name='invoice_incoterm_id']"
                 position="after"
             >
-                <field
-                    name="intrastat_transaction_id"
-                    domain="[('company_id', '=', company_id)]"
-                />
+                <field name="intrastat_transaction_id" />
                 <field name="intrastat" invisible="1" />
                 <field
                     name="intrastat_transport_id"


### PR DESCRIPTION
The intrastat transaction domain is already forced in the model and in the field in account.move.
It was being incorrectly forced in the move, where it needed to be associated to the same company as the record, but those types can have no company associated

@Tecnativa
TT29582

ping @pedrobaeza @victoralmau 