### PR TITLE
[11.0][FIX] product_harmonized_system: add migration scripts

### DIFF
--- a/product_harmonized_system/migrations/11.0.1.0.0/end-migration.py
+++ b/product_harmonized_system/migrations/11.0.1.0.0/end-migration.py
@@ -1,0 +1,40 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2021 ForgeFlow <http://www.forgeflow.com>
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+from openupgradelib import openupgrade_merge_records  # pylint: disable=W7936
+
+
+def merge_duplicated_hs_codes(env):
+    # if exist duplicates, remove them
+    openupgrade.logged_query(
+        env.cr, """
+        WITH duplicated AS (
+            SELECT count(*), local_code, company_id
+            FROM hs_code
+            GROUP BY local_code, company_id
+            HAVING count(*) > 1
+        )
+        SELECT hc.id, hc.local_code, hc.company_id
+        FROM hs_code hc
+        JOIN duplicated ON (hc.local_code = duplicated.local_code
+            AND hc.company_id = duplicated.company_id)
+        ORDER BY hc.active DESC NULLS LAST, hc.id ASC
+        """
+    )
+    companies = {}
+    for hs_code_id, local_code, company_id in env.cr.fetchall():
+        companies.setdefault(company_id, {}).setdefault(
+            local_code, []).append(hs_code_id)
+    for company_id in companies:
+        for local_code in companies[company_id]:
+            openupgrade_merge_records.merge_records(
+                env, "hs.code", companies[company_id][local_code],
+                companies[company_id][local_code][0],
+                method='sql', delete=True,
+                exclude_columns=None, model_table="hs_code")
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    merge_duplicated_hs_codes(env)

--- a/product_harmonized_system/migrations/11.0.1.0.0/pre-migration.py
+++ b/product_harmonized_system/migrations/11.0.1.0.0/pre-migration.py
@@ -1,0 +1,24 @@
+# Copyright 2021 ForgeFlow <http://www.forgeflow.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def fill_hs_code_company_id(env):
+    # to avoid local_code_company_uniq constraint error
+    openupgrade.logged_query(
+        env.cr, """
+        ALTER TABLE hs_code
+        DROP CONSTRAINT IF EXISTS hs_code_local_code_company_uniq
+        """)
+    openupgrade.logged_query(
+        env.cr, """
+            UPDATE hs_code hc
+            SET company_id = ru.company_id
+            FROM res_users ru
+            WHERE hc.create_uid = ru.id AND hc.company_id IS NULL"""
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    fill_hs_code_company_id(env)


### PR DESCRIPTION
To avoid `local_code_company_uniq` constraint error.

It was a new constraint added in v11 due to company_id being required, and if you have some duplicated hs codes, the constraint is breaking.