### PR TITLE
[13.0][IMP] intrastat_product: add support for Brexit + small performance i…

### DIFF
--- a/intrastat_product/__manifest__.py
+++ b/intrastat_product/__manifest__.py
@@ -20,6 +20,7 @@
         "report_xlsx_helper",
     ],
     "excludes": ["account_intrastat"],
+    "external_dependencies": {"python": ["python-stdnum>=1.16"]},
     "data": [
         "security/intrastat_security.xml",
         "security/ir.model.access.csv",

--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -24,16 +24,10 @@ class AccountMove(models.Model):
     src_dest_country_id = fields.Many2one(
         comodel_name="res.country",
         string="Origin/Destination Country",
-        compute="_compute_intrastat_country",
+        compute="_compute_src_dest_country_id",
         store=True,
         compute_sudo=True,
         help="Destination country for dispatches. Origin country for " "arrivals.",
-    )
-    intrastat_country = fields.Boolean(
-        compute="_compute_intrastat_country",
-        string="Intrastat Country",
-        store=True,
-        compute_sudo=True,
     )
     src_dest_region_id = fields.Many2one(
         comodel_name="intrastat.region",
@@ -53,13 +47,12 @@ class AccountMove(models.Model):
     )
 
     @api.depends("partner_shipping_id.country_id", "partner_id.country_id")
-    def _compute_intrastat_country(self):
+    def _compute_src_dest_country_id(self):
         for inv in self:
             country = inv.partner_shipping_id.country_id or inv.partner_id.country_id
             if not country:
                 country = inv.company_id.country_id
             inv.src_dest_country_id = country.id
-            inv.intrastat_country = country.intrastat
 
     @api.model
     def _default_src_dest_region_id(self):

--- a/intrastat_product/models/hs_code.py
+++ b/intrastat_product/models/hs_code.py
@@ -3,8 +3,7 @@
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 # @author Luc de Meyer <info@noviat.com>
 
-from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo import fields, models
 
 
 class HSCode(models.Model):
@@ -13,24 +12,3 @@ class HSCode(models.Model):
     intrastat_unit_id = fields.Many2one(
         comodel_name="intrastat.unit", string="Intrastat Supplementary Unit"
     )
-
-    @api.constrains("local_code")
-    def _hs_code(self):
-        if self.company_id.country_id.intrastat:
-            if not self.local_code.isdigit():
-                raise ValidationError(
-                    _(
-                        "Intrastat Codes should only contain digits. "
-                        "This is not the case for code '%s'."
-                    )
-                    % self.local_code
-                )
-            if len(self.local_code) != 8:
-                raise ValidationError(
-                    _(
-                        "Intrastat Codes should "
-                        "contain 8 digits. This is not the case for "
-                        "Intrastat Code '%s' which has %d digits."
-                    )
-                    % (self.local_code, len(self.local_code))
-                )

--- a/intrastat_product/report/intrastat_product_report_xls.py
+++ b/intrastat_product/report/intrastat_product_report_xls.py
@@ -140,6 +140,16 @@ class IntrastatProductDeclarationXlsx(models.AbstractModel):
                 "line": {"value": self._render("line.region_id.name or ''")},
                 "width": 28,
             },
+            "vat": {
+                "header": {"type": "string", "value": self._("VAT")},
+                "line": {"value": self._render("line.vat or ''")},
+                "width": 20,
+            },
+            "partner_id": {
+                "header": {"type": "string", "value": self._("Partner")},
+                "line": {"value": self._render("line.partner_id.display_name or ''")},
+                "width": 28,
+            },
             "invoice": {
                 "header": {"type": "string", "value": self._("Invoice")},
                 "line": {"value": self._render("line.invoice_id.name")},

--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -214,10 +214,7 @@
                     />
                     <field name="product_id" />
                     <field name="hs_code_id" />
-                    <field
-                        name="src_dest_country_id"
-                        domain="[('intrastat', '=', True)]"
-                    />
+                    <field name="src_dest_country_id" />
                     <field
                         name="amount_company_currency"
                         widget="monetary"
@@ -245,6 +242,8 @@
                     <field name="incoterm_id" invisible="1" />
                     <field name="region_id" invisible="1" />
                     <field name="product_origin_country_id" invisible="1" />
+                    <field name="vat" />
+                    <field name="partner_id" />
                     <field name="invoice_id" />
                 </group>
                 <group string="Declaration" name="declaration">
@@ -264,7 +263,7 @@
                 />
                 <field name="product_id" />
                 <field name="hs_code_id" />
-                <field name="src_dest_country_id" domain="[('intrastat', '=', True)]" />
+                <field name="src_dest_country_id" />
                 <field name="amount_company_currency" />
                 <field name="amount_accessory_cost_company_currency" />
                 <field name="transaction_id" />
@@ -284,6 +283,7 @@
                     invisible="1"
                     string="Product C/O"
                 />
+                <field name="vat" />
                 <field name="invoice_id" />
                 <field name="type" invisible="1" />
                 <field name="reporting_level" invisible="1" />
@@ -301,10 +301,7 @@
                         invisible="not context.get('intrastat_product_declaration_line_main_view')"
                     />
                     <field name="hs_code_id" />
-                    <field
-                        name="src_dest_country_id"
-                        domain="[('intrastat', '=', True)]"
-                    />
+                    <field name="src_dest_country_id" />
                     <field
                         name="amount_company_currency"
                         widget="monetary"
@@ -327,6 +324,7 @@
                     <field name="region_id" invisible="1" />
                     <field name="incoterm_id" invisible="1" />
                     <field name="product_origin_country_id" invisible="1" />
+                    <field name="vat" />
                 </group>
                 <group name="computation" string="Related Transactions">
                     <field name="computation_line_ids" nolabel="1" />
@@ -344,7 +342,7 @@
                     invisible="not context.get('intrastat_product_declaration_line_main_view')"
                 />
                 <field name="hs_code_id" />
-                <field name="src_dest_country_id" domain="[('intrastat', '=', True)]" />
+                <field name="src_dest_country_id" />
                 <field name="amount_company_currency" />
                 <field name="transaction_id" />
                 <field name="weight" />
@@ -363,6 +361,7 @@
                     invisible="1"
                     string="Product C/O"
                 />
+                <field name="vat" />
             </tree>
         </field>
     </record>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# generated from manifests external_dependencies
+python-stdnum>=1.16


### PR DESCRIPTION
…mprovement + remove universal hs_code constaint

Add support for post-Brexit VAT numbers with latest python-stdnum version
Remove use of country_id.intrastat
Add 'vat' field on computation and declaration lines with a simple validity check
Add 'partner_id' field on computation lines
Prevent back to draft when an XML export is present
Remove the universal constaint applied to the hs_codes for countries in the "Europe" list, as discussed in https://github.com/OCA/intrastat-extrastat/pull/116#discussion_r569735555

Co-authored-by: Alexis de Lattre <alexis.delattre@akretion.com>


Backport of: https://github.com/OCA/intrastat-extrastat/pull/120/commits/2646dc489ed76000d5eb0356ded1a71d60bf5a67