### PR TITLE
[13.0] product_harmonized_system: do not require company on hs_code model

### DIFF
--- a/product_harmonized_system/models/hs_code.py
+++ b/product_harmonized_system/models/hs_code.py
@@ -34,8 +34,6 @@ class HSCode(models.Model):
     company_id = fields.Many2one(
         "res.company",
         string="Company",
-        readonly=True,
-        required=True,
         default=lambda self: self._default_company_id(),
     )
     product_categ_ids = fields.One2many(


### PR DESCRIPTION
This PR intends to remove the requirement of setting a company to an HS Code since HS code should be considered as "physical" property of a product which should not depend on the company and can be shared across companies.

cc ~ @ForgeFlow