### PR TITLE
[14.0] product_harmonized_system_delivery: hs_code is now store=True

### DIFF
--- a/product_harmonized_system/models/hs_code.py
+++ b/product_harmonized_system/models/hs_code.py
@@ -53,7 +53,7 @@ class HSCode(models.Model):
 
     @api.model
     def _default_company_id(self):
-        return self.env.company
+        return False
 
     @api.depends("local_code")
     def _compute_hs_code(self):

--- a/product_harmonized_system/views/product_template.xml
+++ b/product_harmonized_system/views/product_template.xml
@@ -23,4 +23,17 @@
             </field>
         </field>
     </record>
+    <record id="product_template_search_view" model="ir.ui.view">
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_search_view" />
+        <field name="arch" type="xml">
+            <filter name="categ_id" position="after">
+                <filter
+                    string="H.S. Code"
+                    name="hs_code_groupby"
+                    context="{'group_by': 'hs_code_id'}"
+                />
+            </filter>
+        </field>
+    </record>
 </odoo>

--- a/product_harmonized_system_delivery/models/product.py
+++ b/product_harmonized_system_delivery/models/product.py
@@ -7,5 +7,4 @@ from odoo import fields, models
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    # this field cannot be stored because hs_code_id is company dependent
-    hs_code = fields.Char(related="hs_code_id.hs_code", readonly=True, store=False)
+    hs_code = fields.Char(related="hs_code_id.hs_code", store=True)


### PR DESCRIPTION
This commit is the "followup" of the change to company_dependent=False on the fields hs_code_id on product.template and product.category, cf #156 
Add groupby on hs_code_id on product.template search view
hs.code is now company_id=False by default