### PR TITLE
[13.0]Intrastat Brexit support

### DIFF
--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -1,9 +1,10 @@
 # Copyright 2011-2017 Akretion France (http://www.akretion.com)
-# Copyright 2009-2020 Noviat (http://www.noviat.com)
+# Copyright 2009-2021 Noviat (http://www.noviat.com)
 # @author Alexis de Lattre <alexis.delattre@akretion.com>
 # @author Luc de Meyer <info@noviat.com>
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class AccountMove(models.Model):
@@ -90,13 +91,17 @@ class AccountMove(models.Model):
             if not hs_code:
                 return vals
             weight, qty = decl_model._get_weight_and_supplunits(line, hs_code)
+            product_origin_country = line.product_id.origin_country_id
+            product_origin_country_code = decl_model._get_product_origin_country_code(
+                line, product_origin_country
+            )
             vals.update(
                 {
                     "invoice_line_id": line.id,
                     "hs_code_id": hs_code.id,
                     "transaction_weight": int(weight),
                     "transaction_suppl_unit_qty": qty,
-                    "product_origin_country_id": line.product_id.origin_country_id.id,
+                    "product_origin_country_code": product_origin_country_code,
                 }
             )
         return vals
@@ -155,10 +160,21 @@ class AccountMoveIntrastatLine(models.Model):
     transaction_weight = fields.Integer(
         help="Transaction weight in Kg: Quantity x Product Weight"
     )
+    # product_origin_country_id is replaced by product_origin_country_code
+    # this field should be dropped once the localisation modules have been
+    # adapted accordingly
     product_origin_country_id = fields.Many2one(
         comodel_name="res.country",
         string="Country of Origin",
         help="Country of origin of the product i.e. product " "'made in ____'.",
+    )
+    product_origin_country_code = fields.Char(
+        string="Country of Origin of the Product",
+        required=True,
+        default="QU",
+        help="2 digit code of country of origin of the product except for the UK.\n"
+        "Specify 'XI' for UK Northern Ireland and 'XU' for rest of the UK.\n"
+        "Specify 'QU' when the country is unknown.\n",
     )
 
     @api.onchange("invoice_line_id")
@@ -171,3 +187,25 @@ class AccountMoveIntrastatLine(models.Model):
             ("id", "not in", moves.mapped("intrastat_line_ids.invoice_line_id").ids),
         ]
         return {"domain": {"invoice_line_id": dom}}
+
+    @api.model
+    def create(self, vals):
+        self._format_vals(vals)
+        return super().create(vals)
+
+    def write(self, vals):
+        self._format_vals(vals)
+        return super().write(vals)
+
+    def _format_vals(self, vals):
+        if "product_origin_country_code" in vals:
+            vals["product_origin_country_code"] = (
+                vals["product_origin_country_code"].upper().strip()
+            )
+            if len(vals["product_origin_country_code"]) != 2:
+                raise UserError(
+                    _(
+                        "Intrastat transaction details error:\n"
+                        "Product Origin Country Code must be 2 characters."
+                    )
+                )

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -752,7 +752,7 @@ class IntrastatProductDeclaration(models.Model):
             "transaction": computation_line.transaction_id.id or False,
             "transport": computation_line.transport_id.id or False,
             "region": computation_line.region_id.id or False,
-            "product_origin_country_code": computation_line.product_origin_country_code,
+            "product_origin_country": computation_line.product_origin_country_code,
         }
 
     def group_line_hashcode(self, computation_line):

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -421,8 +421,22 @@ class IntrastatProductDeclaration(models.Model):
             self._account_config_warning(msg)
         return incoterm
 
-    def _get_product_origin_country(self, inv_line):
-        return inv_line.product_id.origin_country_id
+    def _get_product_origin_country_code(self, inv_line, product_origin_country):
+        product_origin_country_code = "QU"
+        if product_origin_country.code:
+            product_origin_country_code = product_origin_country.code
+            year = self.year or str(inv_line.move_id.date.year)
+            if year >= "2021":
+                if (
+                    hasattr(inv_line.product_id, "origin_state_id")
+                    and inv_line.product_id.origin_state_id
+                    and inv_line.product_id.origin_state_id.name.lower()
+                    == "northern ireland"
+                ):
+                    product_origin_country_code = "XI"
+                elif inv_line.product_id.origin_country_id.code == "GB":
+                    product_origin_country_code = "XU"
+        return product_origin_country_code
 
     def _update_computation_line_vals(self, inv_line, line_vals):
         """ placeholder for localization modules """
@@ -611,11 +625,14 @@ class IntrastatProductDeclaration(models.Model):
                 total_inv_product_cc += amount_company_currency
 
                 if inv_intrastat_line:
-                    product_origin_country = (
-                        inv_intrastat_line.product_origin_country_id
+                    product_origin_country_code = (
+                        inv_intrastat_line.product_origin_country_code
                     )
                 else:
-                    product_origin_country = self._get_product_origin_country(inv_line)
+                    product_origin_country = inv_line.product_id.origin_country_id
+                    product_origin_country_code = self._get_product_origin_country_code(
+                        inv_line, product_origin_country
+                    )
 
                 region = self._get_region(inv_line)
 
@@ -630,7 +647,7 @@ class IntrastatProductDeclaration(models.Model):
                     "amount_company_currency": amount_company_currency,
                     "amount_accessory_cost_company_currency": 0.0,
                     "transaction_id": intrastat_transaction.id,
-                    "product_origin_country_id": product_origin_country.id or False,
+                    "product_origin_country_code": product_origin_country_code,
                     "region_id": region and region.id or False,
                 }
 
@@ -743,8 +760,7 @@ class IntrastatProductDeclaration(models.Model):
             "transaction": computation_line.transaction_id.id or False,
             "transport": computation_line.transport_id.id or False,
             "region": computation_line.region_id.id or False,
-            "product_origin_country": computation_line.product_origin_country_id.id
-            or False,
+            "product_origin_country_code": computation_line.product_origin_country_code,
         }
 
     def group_line_hashcode(self, computation_line):
@@ -762,7 +778,7 @@ class IntrastatProductDeclaration(models.Model):
             "transport_id": computation_line.transport_id.id,
             "region_id": computation_line.region_id.id,
             "parent_id": computation_line.parent_id.id,
-            "product_origin_country_id": computation_line.product_origin_country_id.id,
+            "product_origin_country_code": computation_line.product_origin_country_code,
             "amount_company_currency": 0.0,
         }
         for field in fields_to_sum:
@@ -972,14 +988,25 @@ class IntrastatProductComputationLine(models.Model):
         "intrastat.transaction", string="Intrastat Transaction"
     )
     region_id = fields.Many2one("intrastat.region", string="Intrastat Region")
-    # extended declaration
-    incoterm_id = fields.Many2one("account.incoterms", string="Incoterm")
-    transport_id = fields.Many2one("intrastat.transport_mode", string="Transport Mode")
+    # product_origin_country_id is replaced by product_origin_country_code
+    # this field should be dropped once the localisation modules have been
+    # adapted accordingly
     product_origin_country_id = fields.Many2one(
         "res.country",
         string="Country of Origin of the Product",
         help="Country of origin of the product i.e. product 'made in ____'",
     )
+    product_origin_country_code = fields.Char(
+        string="Country of Origin of the Product",
+        required=True,
+        default="QU",
+        help="2 digit code of country of origin of the product except for the UK.\n"
+        "Specify 'XI' for UK Northern Ireland and 'XU' for rest of the UK.\n"
+        "Specify 'QU' when the country is unknown.\n",
+    )
+    # extended declaration
+    incoterm_id = fields.Many2one("account.incoterms", string="Incoterm")
+    transport_id = fields.Many2one("intrastat.transport_mode", string="Transport Mode")
 
     @api.depends("transport_id")
     def _compute_check_validity(self):
@@ -1052,11 +1079,22 @@ class IntrastatProductDeclarationLine(models.Model):
         "intrastat.transaction", string="Intrastat Transaction"
     )
     region_id = fields.Many2one("intrastat.region", string="Intrastat Region")
-    # extended declaration
-    incoterm_id = fields.Many2one("account.incoterms", string="Incoterm")
-    transport_id = fields.Many2one("intrastat.transport_mode", string="Transport Mode")
+    # product_origin_country_id is replaced by product_origin_country_code
+    # this field should be dropped once the localisation modules have been
+    # adapted accordingly
     product_origin_country_id = fields.Many2one(
         "res.country",
         string="Country of Origin of the Product",
         help="Country of origin of the product i.e. product 'made in ____'",
     )
+    product_origin_country_code = fields.Char(
+        string="Country of Origin of the Product",
+        required=True,
+        default="QU",
+        help="2 digit code of country of origin of the product except for the UK.\n"
+        "Specify 'XI' for UK Northern Ireland and 'XU' for rest of the UK.\n"
+        "Specify 'QU' when the country is unknown.\n",
+    )
+    # extended declaration
+    incoterm_id = fields.Many2one("account.incoterms", string="Incoterm")
+    transport_id = fields.Many2one("intrastat.transport_mode", string="Transport Mode")

--- a/intrastat_product/report/intrastat_product_report_xls.py
+++ b/intrastat_product/report/intrastat_product_report_xls.py
@@ -36,9 +36,9 @@ class IntrastatProductDeclarationXlsx(models.AbstractModel):
                 "header": {"type": "string", "value": self._("Product C/O")},
                 "line": {
                     "type": "string",
-                    "value": self._render("line.product_origin_country_id.name or ''"),
+                    "value": self._render("line.product_origin_country_code or ''"),
                 },
-                "width": 28,
+                "width": 3,
             },
             "hs_code": {
                 "header": {"type": "string", "value": self._("Intrastat Code")},

--- a/intrastat_product/views/account_move.xml
+++ b/intrastat_product/views/account_move.xml
@@ -47,10 +47,7 @@
                             <field name="transaction_suppl_unit_qty" />
                             <field name="hs_code_id" />
                             <field name="transaction_weight" />
-                            <field
-                                name="product_origin_country_id"
-                                options="{'no_create': True, 'no_open': True}"
-                            />
+                            <field name="product_origin_country_code" />
                         </tree>
                     </field>
                 </page>

--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -244,7 +244,12 @@
                     />
                     <field name="incoterm_id" invisible="1" />
                     <field name="region_id" invisible="1" />
+                    <!-- TODO: remove product_origin_country_id after update of localization modules -->
                     <field name="product_origin_country_id" invisible="1" />
+                    <field
+                        name="product_origin_country_code"
+                        attrs="{'invisible': [('type', '!=', 'arrivals')]}"
+                    />
                     <field name="invoice_id" />
                 </group>
                 <group string="Declaration" name="declaration">
@@ -279,9 +284,15 @@
                     attrs="{'required': [('reporting_level', '=', 'extended')], 'invisible': [('reporting_level', '!=', 'extended')]}"
                 />
                 <field name="region_id" invisible="1" />
+                <!-- TODO: remove product_origin_country_id after update of localization modules -->
                 <field
                     name="product_origin_country_id"
                     invisible="1"
+                    string="Product C/O"
+                />
+                <field
+                    name="product_origin_country_code"
+                    attrs="{'column_invisible': [('parent.type', '=', 'arrivals')]}"
                     string="Product C/O"
                 />
                 <field name="invoice_id" />
@@ -326,7 +337,12 @@
                     />
                     <field name="region_id" invisible="1" />
                     <field name="incoterm_id" invisible="1" />
+                    <!-- TODO: remove product_origin_country_id after update of localization modules -->
                     <field name="product_origin_country_id" invisible="1" />
+                    <field
+                        name="product_origin_country_code"
+                        attrs="{'invisible': [('type', '!=', 'arrivals')]}"
+                    />
                 </group>
                 <group name="computation" string="Related Transactions">
                     <field name="computation_line_ids" nolabel="1" />
@@ -358,9 +374,15 @@
                 />
                 <field name="region_id" invisible="1" />
                 <field name="incoterm_id" invisible="1" />
+                <!-- TODO: remove product_origin_country_id after update of localization modules -->
                 <field
                     name="product_origin_country_id"
                     invisible="1"
+                    string="Product C/O"
+                />
+                <field
+                    name="product_origin_country_code"
+                    attrs="{'column_invisible': [('parent.type', '=', 'arrivals')]}"
                     string="Product C/O"
                 />
             </tree>

--- a/product_harmonized_system/models/product_template.py
+++ b/product_harmonized_system/models/product_template.py
@@ -21,9 +21,19 @@ class ProductTemplate(models.Model):
         "and configure the H.S. code on the product category.",
     )
     origin_country_id = fields.Many2one(
-        "res.country",
+        comodel_name="res.country",
         string="Country of Origin",
         help="Country of origin of the product i.e. product " "'made in ____'.",
+    )
+    origin_state_id = fields.Many2one(
+        comodel_name="res.country.state",
+        string="Country State of Origin",
+        domain="[('country_id', '=?', origin_country_id)]",
+        help="Country State of origin of the product.\n"
+        "This field is used for the Intrastat declaration, "
+        "selecting 'Northern Ireland' will set the code 'XI' "
+        "for products from the United Kingdom whereas code 'XU' "
+        "will be used for the other UK states.",
     )
 
 

--- a/product_harmonized_system/views/product_template.xml
+++ b/product_harmonized_system/views/product_template.xml
@@ -20,6 +20,10 @@
                     name="origin_country_id"
                     attrs="{'invisible': [('type', '=', 'service')]}"
                 />
+                <field
+                    name="origin_state_id"
+                    attrs="{'invisible': [('type', '=', 'service')]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This PR now handles correctly the XI and XU country codes introduced by the brexit.