### PR TITLE
[13.0]intrastat_product - fix read error on intrastat_line_ids

### DIFF
--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -107,11 +107,14 @@ class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
     hs_code_id = fields.Many2one(
-        comodel_name="hs.code", compute="_compute_hs_code_id", string="Intrastat Code",
+        comodel_name="hs.code",
+        compute="_compute_hs_code_id",
+        string="Intrastat Code",
+        compute_sudo=True,
     )
 
     def _compute_hs_code_id(self):
-        for rec in self.sudo():
+        for rec in self:
             intrastat_line = rec.move_id.intrastat_line_ids.filtered(
                 lambda r: r.invoice_line_id == rec
             )

--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -49,6 +49,7 @@ class AccountMove(models.Model):
     intrastat_line_ids = fields.One2many(
         comodel_name="account.move.intrastat.line",
         inverse_name="move_id",
+        groups="intrastat_product.group_invoice_intrastat_transaction_details",
         string="Intrastat declaration details",
     )
 
@@ -110,8 +111,8 @@ class AccountMoveLine(models.Model):
     )
 
     def _compute_hs_code_id(self):
-        for rec in self:
-            intrastat_line = self.move_id.intrastat_line_ids.filtered(
+        for rec in self.sudo():
+            intrastat_line = rec.move_id.intrastat_line_ids.filtered(
                 lambda r: r.invoice_line_id == rec
             )
             rec.hs_code_id = (


### PR DESCRIPTION
This PR fixes the following issue: 
Users not belonging to the billing group (e.g. Sales trying to see the invoice linked to a Sale Order) get an access error on the account.move.intrastat.line object.