### PR TITLE
[14.0]intrastat_product - remove incorrect domain on comutation line

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -1048,7 +1048,6 @@ class IntrastatProductComputationLine(models.Model):
         "res.country",
         string="Country",
         help="Country of Origin/Destination",
-        domain=[("intrastat", "=", True)],
     )
     product_id = fields.Many2one(
         "product.product", related="invoice_line_id.product_id"


### PR DESCRIPTION
The intrastat flag has been removed from res.country via https://github.com/OCA/intrastat-extrastat/commit/b7ba7f7f5109d6ab1a47f6b6b261187f02193ea3 but was still hanging around in the computation lines resulting in stack trace when trying to change the country manually on a computation line.