### PR TITLE
[FIX] intrastat_product: fix error creating intrastat declaration

### DIFF
--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -49,7 +49,6 @@ class AccountMove(models.Model):
     intrastat_line_ids = fields.One2many(
         comodel_name="account.move.intrastat.line",
         inverse_name="move_id",
-        groups="intrastat_product.group_invoice_intrastat_transaction_details",
         string="Intrastat declaration details",
     )
 


### PR DESCRIPTION
In https://github.com/OCA/intrastat-extrastat/pull/164 the security group to see intrastat transaction details was added in the intrastat_line_ids fields. However, the users in the group `account.group_account_invoice` are the ones having full rights on model `account.move.intrastat.line`, so if they are not part of the `intrastat_product.group_invoice_intrastat_transaction_details` they now receive an error when generating the declaration.

Either the group is not added in the field or it is changed by the `account.group_account_invoice` group.