### PR TITLE
[13.0][IMP] intrastat_product: Skip invoices according to partner country

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -625,6 +625,13 @@ class IntrastatProductDeclaration(models.Model):
                 partner_country = self._get_partner_country(
                     inv_line, notedict, eu_countries
                 )
+                # When the country is the same as the company's country or the country
+                # does not have the intrastat check marked, it must be skipped.
+                if (
+                    not partner_country.intrastat
+                    or partner_country == self.company_id.country_id
+                ):
+                    continue
                 partner_country_code = (
                     invoice.commercial_partner_id._get_intrastat_country_code()
                 )


### PR DESCRIPTION
Skip invoices according to partner country.

When the country is the same as the company's country or the country does not have the intrastat check marked, it must be skipped for the declaration.

Accidentally removed in https://github.com/OCA/intrastat-extrastat/commit/3713df54f0230fe3059321ce399618074ef3b756

Please @pedrobaeza can you review it?

@Tecnativa TT38922