### PR TITLE
[14.0][IMP] intrastat_product: Skip invoices according to partner country

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -691,6 +691,9 @@ class IntrastatProductDeclaration(models.Model):
                 partner_country = self._get_partner_country(
                     inv_line, notedict, eu_countries
                 )
+                # When the country is the same as the company's country must be skipped.
+                if partner_country == self.company_id.country_id:
+                    continue
                 partner_country_code = (
                     invoice.commercial_partner_id._get_intrastat_country_code()
                 )


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/intrastat-extrastat/pull/192

Skip invoices according to partner country.

When the country is the same as the company's country or the country does not have the intrastat check marked, it must be skipped for the declaration.

Accidentally removed in https://github.com/OCA/intrastat-extrastat/commit/2646dc489ed76000d5eb0356ded1a71d60bf5a67

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT38922