### PR TITLE
[13.0][FIX] intrastat_product: Set the correct country code when the country of the delivery address is different (and to be consistent with the src_dest_country_id field).

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -586,6 +586,7 @@ class IntrastatProductDeclaration(models.Model):
         domain = self._prepare_invoice_domain()
         order = "journal_id, name"
         invoices = self.env["account.move"].search(domain, order=order)
+        partner_model = self.env["res.partner"]
 
         for invoice in invoices:
 
@@ -632,8 +633,8 @@ class IntrastatProductDeclaration(models.Model):
                     or partner_country == self.company_id.country_id
                 ):
                     continue
-                partner_country_code = (
-                    invoice.commercial_partner_id._get_intrastat_country_code()
+                partner_country_code = partner_model._get_intrastat_country_code(
+                    country=partner_country, state=invoice.partner_shipping_id.state_id
                 )
 
                 if inv_intrastat_line:


### PR DESCRIPTION
Related to https://github.com/OCA/l10n-spain/pull/2671

Set the correct country code when the country of the delivery address is different (and to be consistent with the `src_dest_country_id` field).

Please @pedrobaeza can you review it?

@Tecnativa TT40764