### PR TITLE
[15.0][FIX] intrastat_product: Avoid error if we create lines manually

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -1152,7 +1152,7 @@ class IntrastatProductComputationLine(models.Model):
     @api.onchange("src_dest_country_id")
     def _onchange_src_dest_country_id(self):
         self.src_dest_country_code = self.src_dest_country_id.code
-        if self.parent_id.year >= "2021":
+        if self.parent_id.year >= "2021" and self.src_dest_country_id:
             self.src_dest_country_code = self.env[
                 "res.partner"
             ]._get_intrastat_country_code(country=self.src_dest_country_id)
@@ -1176,8 +1176,6 @@ class IntrastatProductComputationLine(models.Model):
     def _onchange_product(self):
         self.weight = 0.0
         self.suppl_unit_qty = 0.0
-        self.intrastat_code_id = False
-        self.intrastat_unit_id = False
         if self.product_id:
             self.intrastat_code_id = self.product_id.intrastat_id
             self.intrastat_unit_id = self.product_id.intrastat_id.intrastat_unit_id
@@ -1264,7 +1262,7 @@ class IntrastatProductDeclarationLine(models.Model):
     @api.onchange("src_dest_country_id")
     def _onchange_src_dest_country_id(self):
         self.src_dest_country_code = self.src_dest_country_id.code
-        if self.parent_id.year >= "2021":
+        if self.parent_id.year >= "2021" and self.src_dest_country_id:
             self.src_dest_country_code = self.env[
                 "res.partner"
             ]._get_intrastat_country_code(country=self.src_dest_country_id)

--- a/intrastat_product/tests/test_intrastat_product.py
+++ b/intrastat_product/tests/test_intrastat_product.py
@@ -69,6 +69,26 @@ class TestIntrastatProduct(IntrastatProductCommon):
         decl_copy = self.declaration.copy()
         self.assertEqual(self.declaration.revision + 1, decl_copy.revision)
 
+    def test_declaration_manual_lines(self):
+        vals = {"declaration_type": "dispatches"}
+        self._create_declaration(vals)
+        computation_line_form = Form(
+            self.env["intrastat.product.computation.line"].with_context(
+                default_parent_id=self.declaration.id
+            )
+        )
+        computation_line_form.src_dest_country_code = "FR"
+        computation_line = computation_line_form.save()
+        self.assertEqual(computation_line.src_dest_country_code, "FR")
+        declaration_line_form = Form(
+            self.env["intrastat.product.declaration.line"].with_context(
+                default_parent_id=self.declaration.id
+            )
+        )
+        declaration_line_form.src_dest_country_code = "FR"
+        declaration_line = declaration_line_form.save()
+        self.assertEqual(declaration_line.src_dest_country_code, "FR")
+
     def test_declaration_no_country(self):
         self.demo_company.country_id = False
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/intrastat-extrastat/pull/211

Avoid error if we create lines manually

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT40919