### PR TITLE
[13.0][IMP] intrastat_product: Change version to 13.0.3.0.3 not done in https://github.com/OCA/intrastat-extrastat/pull/202

### DIFF
--- a/intrastat_product/__manifest__.py
+++ b/intrastat_product/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Intrastat Product",
-    "version": "13.0.3.0.2",
+    "version": "13.0.3.0.3",
     "category": "Intrastat",
     "license": "AGPL-3",
     "summary": "Base module for Intrastat Product",


### PR DESCRIPTION
Change version to 13.0.3.0.3 not done in https://github.com/OCA/intrastat-extrastat/pull/202

Related to: https://github.com/OCA/l10n-spain/pull/2671#issuecomment-1375248383

Please @pedrobaeza can you review it?

@Tecnativa 