### PR TITLE
[12.0][FIX] intrastat_product: message translation

### DIFF
--- a/intrastat_product/i18n/es.po
+++ b/intrastat_product/i18n/es.po
@@ -856,7 +856,7 @@ msgstr ""
 #, fuzzy, python-format
 msgid "Missing product on invoice line with H.S. code %s in invoice %s."
 msgstr ""
-"Unidad de medida no existe en la línea con %d producto(s) '%s' en factura "
+"Unidad de medida no existe en la línea con producto(s) '%s' en factura "
 "'%s'."
 
 #. module: intrastat_product

--- a/intrastat_product/i18n/fr.po
+++ b/intrastat_product/i18n/fr.po
@@ -862,7 +862,7 @@ msgstr ""
 #, fuzzy, python-format
 msgid "Missing product on invoice line with H.S. code %s in invoice %s."
 msgstr ""
-"Unité de mesure manquante sur la ligne où figurent %d article(s) '%s' sur la "
+"Unité de mesure manquante sur la ligne où figurent article(s) '%s' sur la "
 "facture '%s'."
 
 #. module: intrastat_product

--- a/intrastat_product/i18n/it.po
+++ b/intrastat_product/i18n/it.po
@@ -840,7 +840,7 @@ msgstr ""
 #: code:addons/intrastat_product/models/intrastat_product_declaration.py:234
 #, python-format
 msgid ""
-"Missing unit of measure on the line with %d product(s) '%s' on invoice '%s'."
+"Missing unit of measure on the line with product(s) '%s' on invoice '%s'."
 msgstr ""
 
 #. module: intrastat_product


### PR DESCRIPTION
The “TypeError: not enough arguments for format string” error is raised when translations applied so I have removed the extra argument specified in a string format operation in all translations.