### PR TITLE
[15.0][FIX] intrastat_product: Set the correct country code when the country of the delivery address is different (and to be consistent with the src_dest_country_id field)

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -648,6 +648,7 @@ class IntrastatProductDeclaration(models.Model):
         domain = self._prepare_invoice_domain()
         order = "journal_id, name"
         invoices = self.env["account.move"].search(domain, order=order)
+        partner_model = self.env["res.partner"]
 
         for invoice in invoices:
 
@@ -692,8 +693,8 @@ class IntrastatProductDeclaration(models.Model):
                 # When the country is the same as the company's country must be skipped.
                 if partner_country == self.company_id.country_id:
                     continue
-                partner_country_code = (
-                    invoice.commercial_partner_id._get_intrastat_country_code()
+                partner_country_code = partner_model._get_intrastat_country_code(
+                    country=partner_country, state=invoice.partner_shipping_id.state_id
                 )
 
                 if inv_intrastat_line:

--- a/intrastat_product/tests/test_brexit.py
+++ b/intrastat_product/tests/test_brexit.py
@@ -53,6 +53,7 @@ class TestIntrastatBrexit(IntrastatProductCommon, TransactionCase):
         inv_out_xi = self.inv_obj.with_context(default_move_type="out_invoice").create(
             {
                 "partner_id": self.partner_xi.id,
+                "partner_shipping_id": self.partner_xi.id,
                 "fiscal_position_id": self.position.id,
             }
         )


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/intrastat-extrastat/pull/205

Set the correct country code when the country of the delivery address is different (and to be consistent with the `src_dest_country_id` field).

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT40764