### PR TITLE
[13.0][IMP] intrastat_product: allow multiple intrastat_lines on same so_line

### DIFF
--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -228,17 +228,6 @@ class AccountMoveIntrastatLine(models.Model):
         "Specify 'QU' when the country is unknown.\n",
     )
 
-    @api.onchange("invoice_line_id")
-    def _onchange_move_id(self):
-        moves = self.mapped("move_id")
-        dom = [
-            ("exclude_from_invoice_tab", "=", False),
-            ("display_type", "=", False),
-            ("id", "in", moves.mapped("invoice_line_ids").ids),
-            ("id", "not in", moves.mapped("intrastat_line_ids.invoice_line_id").ids),
-        ]
-        return {"domain": {"invoice_line_id": dom}}
-
     @api.model
     def create(self, vals):
         self._format_vals(vals)


### PR DESCRIPTION
This is a small change in intrastat_product: it allows to create a declaration where multiple intrastat_lines have been created on same so_line. (It is already possible to create multiple intrastat_lines linked to same so line).