### PR TITLE
[13.0][FIX]hs_code_link: properly declare OCA hs_code field on product.template

### DIFF
--- a/hs_code_link/__manifest__.py
+++ b/hs_code_link/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2017 Camptocamp SA
+# Copyright 2023 ForgeFlow <http://www.forgeflow.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "HS Code Link",

--- a/hs_code_link/models/product.py
+++ b/hs_code_link/models/product.py
@@ -1,10 +1,17 @@
 # Copyright 2017 Camptocamp SA
+# Copyright 2023 ForgeFlow <http://www.forgeflow.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    hs_code = fields.Char(related="hs_code_id.hs_code", readonly=True, store=True)
+    # Make it compute non-stored as we will get the value from the bypassed company
+    hs_code = fields.Char(compute="_compute_hs_code")
+
+    @api.depends_context("force_company")
+    def _compute_hs_code(self):
+        for template in self:
+            template.hs_code = template.hs_code_id.hs_code

--- a/hs_code_link/readme/CONTRIBUTORS.rst
+++ b/hs_code_link/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Denis Leemann <denis.leemann@camptocamp.com>
+* Guillem Casassas <guillem.casassas@forgeflow.com>

--- a/hs_code_link/tests/__init__.py
+++ b/hs_code_link/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_hs_code_link

--- a/hs_code_link/tests/test_hs_code_link.py
+++ b/hs_code_link/tests/test_hs_code_link.py
@@ -1,0 +1,62 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo.tests.common import SavepointCase
+
+
+class TestHSCodeLink(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Models
+        cls.company_model = cls.env["res.company"]
+        cls.hs_code_model = cls.env["hs.code"]
+        cls.product_template_model = cls.env["product.template"]
+        cls.property_model = cls.env["ir.property"]
+
+        # Instances
+        cls.company_1 = cls._create_company("Company 1")
+        cls.company_2 = cls._create_company("Company 2")
+
+        cls.hs_code_1 = cls._create_hs_code()
+        cls.hs_code_2 = cls._create_hs_code("12345678910")
+
+        cls.product_template = cls._create_product_template("Product Template 1")
+
+    @classmethod
+    def _create_company(cls, name):
+        return cls.company_model.create({"name": name})
+
+    @classmethod
+    def _create_hs_code(cls, local_code="123456789", description=False):
+        return cls.hs_code_model.create(
+            {"local_code": local_code, "description": description}
+        )
+
+    @classmethod
+    def _create_product_template(cls, name):
+        return cls.product_template_model.create({"name": name})
+
+    def test_01_check_correctly_sync_values_in_different_companies(self):
+        """
+        Check that the values are correctly synced in different companies.
+        """
+        # First Company
+        template_company_1 = self.product_template.with_context(
+            force_company=self.company_1.id
+        )
+        template_company_1.hs_code_id = self.hs_code_1
+        self.assertEqual(
+            template_company_1.hs_code,
+            self.hs_code_1.hs_code,
+            "The H.S. Codes should be the same.",
+        )
+        # Second Company
+        template_company_2 = self.product_template.with_context(
+            force_company=self.company_2.id
+        )
+        template_company_2.hs_code_id = self.hs_code_2
+        self.assertEqual(
+            template_company_2.hs_code,
+            self.hs_code_2.hs_code,
+            "The H.S. Codes should be the same.",
+        )


### PR DESCRIPTION
Before the change, the field was not being updated after the value of the H.S. Code was changed on a Product Template. The related stored field was not working fine with the company-dependent field.
As the `hs_code_id` field is company-dependent, the related `hs_code` value should also be like this and sync the value based on the previous one.

cc @ForgeFlow