### PR TITLE
[16.0][FIX] intrastat_product: Prevent error when adding transaction details on invoices

### DIFF
--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -202,8 +202,7 @@ class AccountMoveIntrastatLine(models.Model):
     def _onchange_move_id(self):
         moves = self.mapped("move_id")
         dom = [
-            ("exclude_from_invoice_tab", "=", False),
-            ("display_type", "=", False),
+            ("display_type", "=", "product"),
             ("id", "in", moves.mapped("invoice_line_ids").ids),
             ("id", "not in", moves.mapped("intrastat_line_ids.invoice_line_id").ids),
         ]


### PR DESCRIPTION
Prevent error when adding transaction details on invoices

The exclude_from_invoice_tab field does not exist in v16.

Please  @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa