### PR TITLE
[16.0][IMP] intrastat_product: method for XLSX filename

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -936,6 +936,30 @@ class IntrastatProductDeclaration(models.Model):
         """
         return {}
 
+    @api.model
+    def _get_xlsx_report_filename(self):
+        self.ensure_one()
+        declaration_type_label = dict(
+            self.fields_get("declaration_type", "selection")["declaration_type"][
+                "selection"
+            ]
+        )[self.declaration_type]
+        draft_label = ""
+        if self.state == "draft":
+            draft_label = (
+                "-%s"
+                % dict(self.fields_get("state", "selection")["state"]["selection"])[
+                    self.state
+                ]
+            )
+        filename = _(
+            "intrastat-%(year_month)s-%(declaration_type)s%(draft)s",
+            year_month=self.year_month,
+            declaration_type=declaration_type_label,
+            draft=draft_label,
+        )
+        return filename
+
     def done(self):
         for decl in self:
             decl.generate_declaration()

--- a/intrastat_product/report/report.xml
+++ b/intrastat_product/report/report.xml
@@ -12,9 +12,7 @@
     <field name="report_type">xlsx</field>
     <field name="report_name">intrastat_product.product_declaration_xls</field>
     <field name="report_file">intrastat_product.product_declaration_xls</field>
-    <field
-            name="print_report_name"
-        >'intrastat-%s-%s%s' % (object.year_month, object.declaration_type, object.state == 'draft' and '-draft' or '')</field>
+    <field name="print_report_name">object._get_xlsx_report_filename()</field>
     <field name="binding_model_id" ref="model_intrastat_product_declaration" />
 </record>
 


### PR DESCRIPTION
In fr.po, there is a mistake in the translation of the string of print_report_name which triggered a crash when printing the report. I think it's not good to have a string like that to translate in the PO files:

```
'intrastat-%s-%s%s' % (object.year_month, object.declaration_type, object.state == 'draft' and '-draft' or '')
```
So I use the same technique as in the invoice report: define a method name in print_report_name and users who want to customize the filename should inherit the method.
Advantage: the method uses the label of the selection fields for object.declaration_type and object.state, instead of the key !