### PR TITLE
[16.0][FIX] intrastat_product: Display note field as html on product declat…

### DIFF
--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -89,7 +89,7 @@
                             />
                         </page>
                         <page string="Notes" name="note">
-                            <field name="note" />
+                            <field name="note" widget="html" />
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
…ation

Note field on `intrastat.product.declaration` is currently being displayed as raw html:

![Screenshot from 2023-11-22 15-24-58](https://github.com/OCA/intrastat-extrastat/assets/31987854/d3008513-8003-4864-ba08-44e885ba424a)

Adds html widget so it is displayed correctly:

![Screenshot from 2023-11-22 15-26-32](https://github.com/OCA/intrastat-extrastat/assets/31987854/679bd306-0976-42c9-a313-4fc61449b548)

