### PR TITLE
[16.0] intrastat_product: add confirmed state + several small fixes/improvements

### DIFF
--- a/intrastat_product/security/ir.model.access.csv
+++ b/intrastat_product/security/ir.model.access.csv
@@ -13,6 +13,9 @@ access_read_purchase_move_intrastat_line,Read access to Purchase User on Invoice
 access_read_account_move_intrastat_line,Read access on Invoice Intrastat Lines,model_account_move_intrastat_line,account.group_account_readonly,1,0,0,0
 access_account_move_intrastat_line,Full access on Invoice Intrastat Lines,model_account_move_intrastat_line,account.group_account_invoice,1,1,1,1
 access_intrastat_product_declaration,Full access on Intrastat Product Declarations to Accountant,model_intrastat_product_declaration,account.group_account_user,1,1,1,1
+access_intrastat_product_declaration_readonly,Read-only access on Intrastat Product Declarations to Auditor,model_intrastat_product_declaration,account.group_account_readonly,1,0,0,0
 access_intrastat_product_computation_line,Full access on Intrastat Product Computation Lines to Accountant,model_intrastat_product_computation_line,account.group_account_user,1,1,1,1
+access_intrastat_product_computation_line_readonly,Readon-only access on Intrastat Product Computation Lines to Auditor,model_intrastat_product_computation_line,account.group_account_readonly,1,0,0,0
 access_intrastat_product_declaration_line,Full access on Intrastat Product Declaration Lines to Accountant,model_intrastat_product_declaration_line,account.group_account_user,1,1,1,1
+access_intrastat_product_declaration_line_readonly,Read-only access on Intrastat Product Declaration Lines to Auditor,model_intrastat_product_declaration_line,account.group_account_readonly,1,0,0,0
 access_intrastat_result_view,Access on intrastat.result.view,model_intrastat_result_view,account.group_account_user,1,1,1,0

--- a/intrastat_product/tests/test_brexit.py
+++ b/intrastat_product/tests/test_brexit.py
@@ -57,7 +57,8 @@ class TestIntrastatBrexit(IntrastatProductCommon, TransactionCase):
             }
         )
         self.declaration.action_gather()
-        self.declaration.done()
+        self.declaration.draft2confirmed()
+        self.declaration.confirmed2done()
         cline = self.declaration.computation_line_ids
         dline = self.declaration.declaration_line_ids
         self.assertEqual(cline.src_dest_country_code, "XI")
@@ -84,7 +85,8 @@ class TestIntrastatBrexit(IntrastatProductCommon, TransactionCase):
             }
         )
         self.declaration.action_gather()
-        self.declaration.done()
+        self.declaration.draft2confirmed()
+        self.declaration.confirmed2done()
         clines = self.declaration.computation_line_ids
         cl_uk = clines.filtered(lambda r: r.product_id == self.product_uk)
         dlines = self.declaration.declaration_line_ids

--- a/intrastat_product/tests/test_purchase_order.py
+++ b/intrastat_product/tests/test_purchase_order.py
@@ -45,7 +45,8 @@ class TestIntrastatProductPurchase(IntrastatPurchaseCommon):
         self.declaration.action_gather()
 
         self._check_line_values()
-        self.declaration.done()
+        self.declaration.draft2confirmed()
+        self.declaration.confirmed2done()
         self._check_line_values(final=True)
 
         # Check the Excel file

--- a/intrastat_product/tests/test_sale_order.py
+++ b/intrastat_product/tests/test_sale_order.py
@@ -80,7 +80,8 @@ class TestIntrastatProductSale(IntrastatSaleCommon):
         self.declaration.action_gather()
 
         self._check_line_values()
-        self.declaration.done()
+        self.declaration.draft2confirmed()
+        self.declaration.confirmed2done()
         self._check_line_values(final=True)
 
         # Check the Excel file

--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -14,18 +14,26 @@
                         class="btn-primary"
                     />
                     <button
-                        name="done"
+                        name="draft2confirmed"
                         string="Confirm"
                         type="object"
                         class="btn-primary"
                         states="draft"
-                        help="Generate declaration lines, generate XML export and set declaration to 'Done'"
+                        help="Generate declaration lines"
+                    />
+                    <button
+                        name="confirmed2done"
+                        string="Generate XML File"
+                        type="object"
+                        class="btn-primary"
+                        states="confirmed"
+                        help="Generate XML file and set declaration to 'Done'"
                     />
                     <button
                         name="back2draft"
                         string="Back to Draft"
                         type="object"
-                        states="done"
+                        states="confirmed,done"
                         confirm="Are you sure you want to go back to draft?"
                     />
                     <button
@@ -38,8 +46,7 @@
                 <sheet>
                     <div class="oe_title">
                         <h1>
-                            <span>Intrastat Product Declaration </span>
-                            <field name="year_month" class="oe_inline" />
+                            <field name="display_name" />
                         </h1>
                     </div>
                     <group name="top-block">
@@ -81,7 +88,11 @@
                                 nolabel="1"
                             />
                         </page>
-                        <page string="Declaration Lines" name="declaration_lines">
+                        <page
+                            string="Declaration Lines"
+                            name="declaration_lines"
+                            states="confirmed,done"
+                        >
                             <field
                                 name="declaration_line_ids"
                                 context="{'declaration_type': declaration_type, 'reporting_level': reporting_level}"
@@ -89,7 +100,7 @@
                             />
                         </page>
                         <page string="Notes" name="note">
-                            <field name="note" widget="html" />
+                            <field name="note" />
                         </page>
                     </notebook>
                 </sheet>
@@ -368,6 +379,7 @@
                         name="parent_id"
                         invisible="not context.get('intrastat_product_declaration_line_main_view')"
                     />
+                    <field name="line_number" />
                     <field name="declaration_type" invisible="1" />
                     <field name="reporting_level" invisible="1" />
                     <field name="company_country_code" invisible="1" />
@@ -437,6 +449,12 @@
                 <field name="declaration_type" invisible="1" />
                 <field name="reporting_level" invisible="1" />
                 <field name="company_country_code" invisible="1" />
+                <field
+                    name="line_number"
+                    optional="show"
+                    string="Line"
+                    decoration-bf="1"
+                />
                 <field
                     name="hs_code_id"
                     attrs="{'column_invisible': [('parent.reporting_level', '!=', 'extended')]}"

--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -165,6 +165,11 @@
                     string="Draft"
                     domain="[('state', '=', 'draft')]"
                 />
+                <filter
+                    name="confirmed"
+                    string="Confirmed"
+                    domain="[('state', '=', 'confirmed')]"
+                />
                 <filter name="done" string="Done" domain="[('state', '=', 'done')]" />
                 <group string="Group By" name="group_by">
                     <filter
@@ -176,6 +181,11 @@
                         name="declaration_type_group_by"
                         string="Type"
                         context="{'group_by': 'declaration_type'}"
+                    />
+                    <filter
+                        name="state_group_by"
+                        string="State"
+                        context="{'group_by': 'state'}"
                     />
                 </group>
             </search>

--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -12,6 +12,7 @@
                         attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('action', '=', 'nihil')]}"
                         string="Generate Lines from Invoices"
                         class="btn-primary"
+                        groups="account.group_account_user"
                     />
                     <button
                         name="draft2confirmed"
@@ -20,6 +21,7 @@
                         class="btn-primary"
                         states="draft"
                         help="Generate declaration lines"
+                        groups="account.group_account_user"
                     />
                     <button
                         name="confirmed2done"
@@ -28,6 +30,7 @@
                         class="btn-primary"
                         states="confirmed"
                         help="Generate XML file and set declaration to 'Done'"
+                        groups="account.group_account_user"
                     />
                     <button
                         name="back2draft"
@@ -35,6 +38,7 @@
                         type="object"
                         states="confirmed,done"
                         confirm="Are you sure you want to go back to draft?"
+                        groups="account.group_account_user"
                     />
                     <button
                         name="%(intrastat_product.intrastat_product_xlsx_report)d"


### PR DESCRIPTION
Add a third step "confirmed" between "draft" and "done". It is necessary to have error messages of XML file generation that refer to declaration lines. It was my idea to generate the declaration lines and the XML at the same time ; but real life experience showed it was not a good idea (sorry for that !). Some error messages that block XML generation could refer to computation lines but not all, because, for the fields that are summed in declaration lines, you really need to check the value in the declaration line and point to it if the value is bad.

Add a new field "line_number" on declaration line, to be used in error message when generating XML file.

Add store=True on 3 computed fields (reporting_level on declaration, src_dest_country_code and product_origin_country_code on computation lines). It fixes a bug on src_dest_country_code and product_origin_country_code on computation lines, when you could not set manually a country code while leaving the m2o field empty.

Improve display_name of intrastat.product.declaration

note field moved from fields.Text to fields.Html