### PR TITLE
[16.0][FIX] intrastat_product: skip invoice with non EU country

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -636,6 +636,9 @@ class IntrastatProductDeclaration(models.Model):
                 partner_country = self._get_partner_country(
                     inv_line, notedict, eu_countries
                 )
+                if notedict["invoice"][notedict["inv_origin"]]:
+                    continue
+
                 # When the country is the same as the company's country must be skipped.
                 if partner_country == self.company_id.country_id:
                     _logger.info(

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -585,6 +585,7 @@ class IntrastatProductDeclaration(models.Model):
     def _gather_invoices_init(self, notedict):
         """placeholder for localization modules"""
 
+    # flake8: noqa: C901
     def _gather_invoices(self, notedict):
         lines = []
         qty_prec = self.env["decimal.precision"].precision_get(
@@ -645,7 +646,7 @@ class IntrastatProductDeclaration(models.Model):
                 partner_country = self._get_partner_country(
                     inv_line, notedict, eu_countries
                 )
-                if notedict["invoice"][notedict["inv_origin"]]:
+                if notedict["inv_origin"] in notedict["invoice"]:
                     continue
 
                 # When the country is the same as the company's country must be skipped.
@@ -662,7 +663,9 @@ class IntrastatProductDeclaration(models.Model):
                     hs_code = inv_intrastat_line.hs_code_id
                 elif inv_line.product_id and self._is_product(inv_line):
                     hs_code = self._get_product_hs_code(inv_line, notedict)
-                    if notedict["invline_origin"] in notedict["product"][inv_line.product_id.display_name]["Missing <em>H.S. Code</em>"]:
+                    if notedict["invline_origin"] in notedict["product"].get(
+                        inv_line.product_id.display_name, {}
+                    ).get("Missing <em>H.S. Code</em>", {}):
                         continue
                 else:
                     _logger.info(
@@ -715,8 +718,12 @@ class IntrastatProductDeclaration(models.Model):
                     "suppl_unit_qty": suppl_unit_qty,
                     "amount_company_currency": amount_company_currency,
                     "amount_accessory_cost_company_currency": 0.0,
-                    "transaction_id": intrastat_transaction and intrastat_transaction.id or False,
-                    "product_origin_country_id": product_origin_country and product_origin_country.id or False,
+                    "transaction_id": intrastat_transaction
+                    and intrastat_transaction.id
+                    or False,
+                    "product_origin_country_id": product_origin_country
+                    and product_origin_country.id
+                    or False,
                     "region_code": region_code or region.code,
                     "region_id": region and region.id or False,
                     "partner_id": partner.id,


### PR DESCRIPTION
Added check to skip the invoice if the method _get_partner_country has resulted in an error because of the country not being a EU country.
Also added hooks to allow having empty values if the field is not required. For example, in the Danish intrastat report some fields are not required under certain circumstances.