### PR TITLE
[17.0][IMP] product_harmonized_system: ACL with an empty group

### DIFF
--- a/product_harmonized_system/security/ir.model.access.csv
+++ b/product_harmonized_system/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_hs_code_group_system,Full access on hs.code to Settings group,model_hs_code,base.group_system,1,1,1,1
-access_hs_code_read,Read access on hs.code to everybody,model_hs_code,,1,0,0,0
+access_hs_code_read,Read access on hs.code to everybody,model_hs_code,base.group_user,1,0,0,0


### PR DESCRIPTION
in v17, a warning appears when you have an ACL with an empty group, so I added `base.group_user` there