### PR TITLE
[13.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/hs_code_link/__manifest__.py
+++ b/hs_code_link/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "HS Code Link",
     "version": "13.0.2.0.0",
     "depends": ["product_harmonized_system", "delivery"],
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/intrastat-extrastat",
     "license": "AGPL-3",
     "category": "Reporting",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 13.0.