### PR TITLE
[10.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/hs_code_link/__manifest__.py
+++ b/hs_code_link/__manifest__.py
@@ -8,7 +8,7 @@
         'product_harmonized_system',
         'delivery',
     ],
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "http://www.camptocamp.com",
     "license": "AGPL-3",
     "category": "Reporting",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 10.0.