### PR TITLE
[16.0][IMP] intrastat_product: if module product_net_weight is installed, use it !

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -380,7 +380,12 @@ class IntrastatProductDeclaration(models.Model):
         elif source_uom.category_id == product.uom_id.category_id:
             # We suppose that, on product.template,
             # the 'weight' field is per uom_id
-            weight = product.weight * source_uom._compute_quantity(
+            # Test if module product_net_weight from OCA/product-attribute is installed
+            if hasattr(product, "net_weight"):
+                product_weight = product.net_weight
+            else:
+                product_weight = product.weight
+            weight = product_weight * source_uom._compute_quantity(
                 line_qty, product.uom_id
             )
         else:


### PR DESCRIPTION
If the OCA module product_net_weight from
https://github.com/OCA/product-attribute is installed, use the field net_weight added by this module instead of the native weight field

Reminder: intrastat asks for net weight. 
In the good old days of Odoo v8, when the native product datamodel had both weight and weight_net fields (cf https://github.com/odoo/odoo/blob/8.0/addons/product/product.py#L546), we used weight_net in the code of intrastat_product, cf https://github.com/OCA/intrastat-extrastat/blob/8.0/intrastat_product/models/intrastat_product_declaration.py#L316