### PR TITLE
[17.0][IMP] intrastat_product: if module product_net_weight is installed, use it

### DIFF
--- a/intrastat_product/README.rst
+++ b/intrastat_product/README.rst
@@ -53,6 +53,12 @@ Installation
 This module is NOT compatible with the *account_intrastat* module from
 Odoo Enterprise.
 
+We recommended to install the module **product_net_weight** from
+``OCA/product-attribute <https://github.com/OCA/product-attribute>``\ \_.
+If this module is installed, Odoo will use the *Net Weight* field of the
+product to compute the intrastat declaration instead of the native
+*Weight* field.
+
 Configuration
 =============
 

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -363,7 +363,12 @@ class IntrastatProductDeclaration(models.Model):
         elif source_uom.category_id == product.uom_id.category_id:
             # We suppose that, on product.template,
             # the 'weight' field is per uom_id
-            weight = product.weight * source_uom._compute_quantity(
+            # Test if module product_net_weight from OCA/product-attribute is installed
+            if hasattr(product, "net_weight"):
+                product_weight = product.net_weight
+            else:
+                product_weight = product.weight
+            weight = product_weight * source_uom._compute_quantity(
                 line_qty, product.uom_id
             )
         else:

--- a/intrastat_product/readme/INSTALL.md
+++ b/intrastat_product/readme/INSTALL.md
@@ -1,2 +1,4 @@
 This module is NOT compatible with the *account_intrastat* module from
 Odoo Enterprise.
+
+We recommended to install the module **product_net_weight** from `OCA/product-attribute <https://github.com/OCA/product-attribute>`_. If this module is installed, Odoo will use the *Net Weight* field of the product to compute the intrastat declaration instead of the native *Weight* field.

--- a/intrastat_product/static/description/index.html
+++ b/intrastat_product/static/description/index.html
@@ -402,6 +402,11 @@ those countries.</p>
 <h1><a class="toc-backref" href="#toc-entry-1">Installation</a></h1>
 <p>This module is NOT compatible with the <em>account_intrastat</em> module from
 Odoo Enterprise.</p>
+<p>We recommended to install the module <strong>product_net_weight</strong> from
+<tt class="docutils literal"><span class="pre">OCA/product-attribute</span> <span class="pre">&lt;https://github.com/OCA/product-attribute&gt;</span></tt>_.
+If this module is installed, Odoo will use the <em>Net Weight</em> field of the
+product to compute the intrastat declaration instead of the native
+<em>Weight</em> field.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-2">Configuration</a></h1>


### PR DESCRIPTION
If the OCA module product_net_weight from
https://github.com/OCA/product-attribute is installed, use the field net_weight added by this module instead of the native weight field

This is a forward port of https://github.com/OCA/intrastat-extrastat/pull/280/files