### PR TITLE
[17.0][FIX]intrastat_product: fix `migrate` method params

### DIFF
--- a/intrastat_product/migrations/17.0.1.1.0/post-migration.py
+++ b/intrastat_product/migrations/17.0.1.1.0/post-migration.py
@@ -6,5 +6,5 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(
-        env.cr, "intrastat_product", "migrations/17.0.1.1.0/noupdate_changes.xml"
+        env, "intrastat_product", "migrations/17.0.1.1.0/noupdate_changes.xml"
     )


### PR DESCRIPTION
Fixes migration script introduced in https://github.com/OCA/intrastat-extrastat/pull/286

cc @ForgeFlow