### PR TITLE
[16.0][FIX] intrastat_product: sale order form view

### DIFF
--- a/intrastat_product/views/sale_order.xml
+++ b/intrastat_product/views/sale_order.xml
@@ -5,14 +5,14 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock" />
         <field name="arch" type="xml">
-            <field name="incoterm" position="after">
+            <group name="sale_shipping" position="inside">
                 <field
                     name="intrastat_transport_id"
                     attrs="{'invisible': [('intrastat', '!=', 'extended')]}"
                     widget="selection"
                 />
                 <field name="intrastat" invisible="1" />
-            </field>
+            </group>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Before this fix, on the sale order form view, the field intrastat_transport_id was between incoterm and incoterm location !

BEFORE
![sale_order_before](https://github.com/user-attachments/assets/c80ffd4d-e778-4643-9a6d-bd017c156026)

AFTER 
![sale_after](https://github.com/user-attachments/assets/4cf481c5-d660-4141-95f9-e2a105de1e4b)
