### PR TITLE
[18.0][FIX] product_harmonized_system: fix hs.code window actions

### DIFF
--- a/product_harmonized_system/views/hs_code.xml
+++ b/product_harmonized_system/views/hs_code.xml
@@ -45,13 +45,13 @@
         <field name="name">Product Categories</field>
         <field name="res_model">product.category</field>
         <field name="view_mode">list,form</field>
-        <field name="domain">[('hs_code_id', '=', id)]</field>
+        <field name="domain">[('hs_code_id', '=', active_id)]</field>
     </record>
     <record id="product_template_hs_code_action" model="ir.actions.act_window">
         <field name="name">Products</field>
         <field name="res_model">product.template</field>
         <field name="view_mode">kanban,list,form</field>
-        <field name="domain">[('hs_code_id', '=', id)]</field>
+        <field name="domain">[('hs_code_id', '=', active_id)]</field>
     </record>
     <!-- Form view for H.S. code -->
     <record id="hs_code_view_form" model="ir.ui.view">


### PR DESCRIPTION
Fix error that prevent us to open window actions from h.s code form.
![2025-01-24_11-44](https://github.com/user-attachments/assets/74557ba1-5418-44bb-8907-ec775896569d)

Error:
![2025-01-24_11-45](https://github.com/user-attachments/assets/20995232-4048-4b74-b269-86db31f67809)
