### PR TITLE
[18.0][FW] [14.0] product_harmonized_system_delivery: hs_code is now store=True

### DIFF
--- a/.oca/oca-port/blacklist/product_harmonized_system.json
+++ b/.oca/oca-port/blacklist/product_harmonized_system.json
@@ -1,0 +1,7 @@
+{
+  "pull_requests": {
+    "OCA/intrastat-extrastat#108": "(auto) Nothing to port from PR #108",
+    "OCA/intrastat-extrastat#154": "(auto) Nothing to port from PR #154",
+    "OCA/intrastat-extrastat#182": "(auto) Nothing to port from PR #182"
+  }
+}

--- a/product_harmonized_system/views/product_template.xml
+++ b/product_harmonized_system/views/product_template.xml
@@ -40,4 +40,17 @@
             </filter>
         </field>
     </record>
+    <record id="product_template_search_view" model="ir.ui.view">
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_search_view" />
+        <field name="arch" type="xml">
+            <filter name="categ_id" position="after">
+                <filter
+                    string="H.S. Code"
+                    name="hs_code_groupby"
+                    context="{'group_by': 'hs_code_id'}"
+                />
+            </filter>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Port from 14.0 to 18.0:
- #159

The following PRs have been blacklisted:
- #108: (auto) Nothing to port from PR #108
- #154: (auto) Nothing to port from PR #154
- #182: (auto) Nothing to port from PR #182