### PR TITLE
[16.0][FIX] intrastat_product: Post-install test + fallback to load CoA

### DIFF
--- a/intrastat_product/tests/common.py
+++ b/intrastat_product/tests/common.py
@@ -3,9 +3,12 @@
 import xlrd
 from werkzeug.urls import url_encode
 
+from odoo.tests import tagged
+
 from odoo.addons.intrastat_base.tests.common import IntrastatCommon
 
 
+@tagged("post_install", "-at_install")
 class IntrastatProductCommon(IntrastatCommon):
     @classmethod
     def _init_products(cls):
@@ -72,6 +75,15 @@ class IntrastatProductCommon(IntrastatCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.region_obj = cls.env["intrastat.region"]
         cls.transaction_obj = cls.env["intrastat.transaction"]
         cls.transport_mode_obj = cls.env["intrastat.transport_mode"]


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with error:

```
odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale
```

provoked by the lack of a CoA installed.

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA, and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa 