### PR TITLE
[16.0][FIX] intrastat_product: api.model is not necessary

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -945,7 +945,6 @@ class IntrastatProductDeclaration(models.Model):
         self.ensure_one()
         self.xml_attachment_id and self.xml_attachment_id.unlink()
 
-    @api.model
     def _xls_computation_line_fields(self):
         """
         Update list in custom module to add/drop columns or change order
@@ -971,7 +970,6 @@ class IntrastatProductDeclaration(models.Model):
             "invoice",
         ]
 
-    @api.model
     def _xls_declaration_line_fields(self):
         """
         Update list in custom module to add/drop columns or change order


### PR DESCRIPTION
@tecnativa TT55417
@pedrobaeza @victoralmau 