### PR TITLE
[18.0][IMP] product_harmonized_system: add an alternative (long) description to hs.code

### DIFF
--- a/product_harmonized_system/models/hs_code.py
+++ b/product_harmonized_system/models/hs_code.py
@@ -27,6 +27,13 @@ class HSCode(models.Model):
     description = fields.Char(
         translate=True, help="Short text description of the H.S. category"
     )
+    long_description = fields.Text(
+        string="Alt. Description",
+        translate=True,
+        help="Alternative text description of the H.S. category. "
+        "This can be, for example, the official description of this category "
+        "as defined in the Harmonized System nomenclature.",
+    )
     local_code = fields.Char(
         required=True,
         help="Code used for the national Import/Export declaration. "

--- a/product_harmonized_system/models/hs_code.py
+++ b/product_harmonized_system/models/hs_code.py
@@ -28,9 +28,9 @@ class HSCode(models.Model):
         translate=True, help="Short text description of the H.S. Code"
     )
     long_description = fields.Text(
-        string="Alt. Description",
+        string="Detailed Description",
         translate=True,
-        help="Alternative text description of the H.S. Code. "
+        help="Detailed text description of the H.S. Code. "
         "This can be, for example, the official description of this code "
         "as defined in the Harmonized System nomenclature.",
     )

--- a/product_harmonized_system/models/hs_code.py
+++ b/product_harmonized_system/models/hs_code.py
@@ -25,13 +25,13 @@ class HSCode(models.Model):
         "http://www.wcoomd.org",
     )
     description = fields.Char(
-        translate=True, help="Short text description of the H.S. category"
+        translate=True, help="Short text description of the H.S. Code"
     )
     long_description = fields.Text(
         string="Alt. Description",
         translate=True,
-        help="Alternative text description of the H.S. category. "
-        "This can be, for example, the official description of this category "
+        help="Alternative text description of the H.S. Code. "
+        "This can be, for example, the official description of this code "
         "as defined in the Harmonized System nomenclature.",
     )
     local_code = fields.Char(

--- a/product_harmonized_system/views/hs_code.xml
+++ b/product_harmonized_system/views/hs_code.xml
@@ -13,7 +13,7 @@
             <search>
                 <field
                     name="local_code"
-                    filter_domain="['|', ('local_code', 'like', self), ('description', 'ilike', self)]"
+                    filter_domain="['|', '|', ('local_code', 'like', self), ('description', 'ilike', self), ('long_description', 'ilike', self)]"
                 />
                 <filter
                     string="Archived"
@@ -32,6 +32,7 @@
                 <field name="hs_code" />
                 <field name="local_code" />
                 <field name="description" optional="show" />
+                <field name="long_description" optional="hide" />
                 <field
                     name="company_id"
                     groups="base.group_multi_company"
@@ -99,6 +100,7 @@
                         <field name="local_code" />
                         <field name="hs_code" />
                         <field name="description" />
+                        <field name="long_description" />
                         <field name="company_id" groups="base.group_multi_company" />
                     </group>
                 </sheet>


### PR DESCRIPTION
It is not always easy to understand exactly which products an HS Code refers to. Adding the possibility for users to include an alternative (long) description, possibly the official explanation of the code, can make their lives easier.