### PR TITLE
[17.0][FIX] intrastat_product: Use Odoo's VAT validation instead of stdnum.vatin.is_valid

### DIFF
--- a/intrastat_product/README.rst
+++ b/intrastat_product/README.rst
@@ -34,10 +34,10 @@ reporting.
 It should be used in combination with country-specific Intrastat Product
 reporting modules such as:
 
-- *l10n_fr_intrastat_product*: the module for the *Déclaration d'Echange
-  de Biens* (DEB) for France
-- *l10n_be_intrastat_product*: the module for the Intrastat Product
-  Declaration for Belgium
+-  *l10n_fr_intrastat_product*: the module for the *Déclaration
+   d'Echange de Biens* (DEB) for France
+-  *l10n_be_intrastat_product*: the module for the Intrastat Product
+   Declaration for Belgium
 
 These country-specific modules can be found in the OCA localization for
 those countries.
@@ -90,40 +90,40 @@ We recommend to start by copying an existing module, e.g.
 l10n_be_intrastat_product and adapt the code for the specific needs of
 your country.
 
-- Declaration Object
+-  Declaration Object
 
-  Create a new class as follows:
+   Create a new class as follows:
 
-  .. code:: python
+   .. code:: python
 
-     class L10nCcIntrastatProductDeclaration(models.Model):
-         _name = 'l10n.cc.intrastat.product.declaration'
-         _description = "Intrastat Product Declaration for YourCountry"
-         _inherit = ['intrastat.product.declaration', 'mail.thread']
+      class L10nCcIntrastatProductDeclaration(models.Model):
+          _name = 'l10n.cc.intrastat.product.declaration'
+          _description = "Intrastat Product Declaration for YourCountry"
+          _inherit = ['intrastat.product.declaration', 'mail.thread']
 
-  whereby cc = your country code
+   whereby cc = your country code
 
-- Computation & Declaration Lines
+-  Computation & Declaration Lines
 
-  Create also new objects inheriting from the Computation and
-  Declaration Line Objects so that you can add methods or customise the
-  methods from the base modules (make a PR when the customization or new
-  method is required for multiple countries).
+   Create also new objects inheriting from the Computation and
+   Declaration Line Objects so that you can add methods or customise the
+   methods from the base modules (make a PR when the customization or
+   new method is required for multiple countries).
 
-  Adapt also the parent_id fields of the newly created objects (cf.
-  l10n_be_intrastat_product as example).
+   Adapt also the parent_id fields of the newly created objects (cf.
+   l10n_be_intrastat_product as example).
 
-- XML Files: Menu, Action, Views
+-  XML Files: Menu, Action, Views
 
-  Cf. l10n_be_istrastat_product as example, replace "be" by your Country
-  Code.
+   Cf. l10n_be_istrastat_product as example, replace "be" by your
+   Country Code.
 
 **Other functionality added by this module:**
 
-- Compute the Intrastat Lines in an invoice. For this, your user needs
-  to be in the "Technical / Invoice Intrastat Transaction Details"
-  group. Go to the "Intrastat transaction details" tab and press
-  **Compute**
+-  Compute the Intrastat Lines in an invoice. For this, your user needs
+   to be in the "Technical / Invoice Intrastat Transaction Details"
+   group. Go to the "Intrastat transaction details" tab and press
+   **Compute**
 
 Known issues / Roadmap
 ======================
@@ -158,16 +158,16 @@ Authors
 Contributors
 ------------
 
-- Alexis de Lattre, Akretion <alexis.delattre@akretion.com>
+-  Alexis de Lattre, Akretion <alexis.delattre@akretion.com>
 
-- Luc De Meyer, Noviat <info@noviat.com>
+-  Luc De Meyer, Noviat <info@noviat.com>
 
-- Denis Roussel <denis.roussel@acsone.eu>
+-  Denis Roussel <denis.roussel@acsone.eu>
 
-- Tecnativa <`www.tecnativa.com\\> <http://www.tecnativa.com\>>`__:
+-  Tecnativa <`www.tecnativa.com <http://www.tecnativa.com>`__>:
 
-     - João Marques
-     - Víctor Martínez
+      -  João Marques
+      -  Víctor Martínez
 
 Maintainers
 -----------

--- a/intrastat_product/__manifest__.py
+++ b/intrastat_product/__manifest__.py
@@ -22,7 +22,6 @@
         "report_xlsx_helper",
     ],
     "excludes": ["account_intrastat"],
-    "external_dependencies": {"python": ["python-stdnum>=1.16"]},
     "data": [
         "security/intrastat_security.xml",
         "security/ir.model.access.csv",

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from datetime import date
 
 from dateutil.relativedelta import relativedelta
-from stdnum.vatin import is_valid
 
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import RedirectWarning, UserError, ValidationError
@@ -1128,9 +1127,18 @@ class IntrastatProductComputationLine(models.Model):
 
     @api.constrains("vat")
     def _check_vat(self):
+        partner_obj = self.env["res.partner"]
         for this in self:
-            if this.vat and not is_valid(this.vat):
-                raise ValidationError(_("The VAT number '%s' is invalid.") % this.vat)
+            if not this.vat:
+                continue
+            country = this.partner_id.commercial_partner_id.country_id
+            if not partner_obj._run_vat_test(this.vat, country):
+                msg = partner_obj._build_vat_error_message(
+                    country and country.code.lower() or None,
+                    this.vat,
+                    _("partner [%s]") % this.partner_id.name,
+                )
+                raise ValidationError(msg)
 
     @api.depends("partner_id")
     def _compute_vat(self):

--- a/intrastat_product/static/description/index.html
+++ b/intrastat_product/static/description/index.html
@@ -375,8 +375,8 @@ reporting.</p>
 <p>It should be used in combination with country-specific Intrastat Product
 reporting modules such as:</p>
 <ul class="simple">
-<li><em>l10n_fr_intrastat_product</em>: the module for the <em>Déclaration d’Echange
-de Biens</em> (DEB) for France</li>
+<li><em>l10n_fr_intrastat_product</em>: the module for the <em>Déclaration
+d’Echange de Biens</em> (DEB) for France</li>
 <li><em>l10n_be_intrastat_product</em>: the module for the Intrastat Product
 Declaration for Belgium</li>
 </ul>
@@ -436,7 +436,7 @@ your country.</p>
 <li><p class="first">Declaration Object</p>
 <p>Create a new class as follows:</p>
 <pre class="code python literal-block">
-<span class="k">class</span> <span class="nc">L10nCcIntrastatProductDeclaration</span><span class="p">(</span><span class="n">models</span><span class="o">.</span><span class="n">Model</span><span class="p">):</span><span class="w">
+<span class="k">class</span><span class="w"> </span><span class="nc">L10nCcIntrastatProductDeclaration</span><span class="p">(</span><span class="n">models</span><span class="o">.</span><span class="n">Model</span><span class="p">):</span><span class="w">
 </span>    <span class="n">_name</span> <span class="o">=</span> <span class="s1">'l10n.cc.intrastat.product.declaration'</span><span class="w">
 </span>    <span class="n">_description</span> <span class="o">=</span> <span class="s2">&quot;Intrastat Product Declaration for YourCountry&quot;</span><span class="w">
 </span>    <span class="n">_inherit</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'intrastat.product.declaration'</span><span class="p">,</span> <span class="s1">'mail.thread'</span><span class="p">]</span>
@@ -446,14 +446,14 @@ your country.</p>
 <li><p class="first">Computation &amp; Declaration Lines</p>
 <p>Create also new objects inheriting from the Computation and
 Declaration Line Objects so that you can add methods or customise the
-methods from the base modules (make a PR when the customization or new
-method is required for multiple countries).</p>
+methods from the base modules (make a PR when the customization or
+new method is required for multiple countries).</p>
 <p>Adapt also the parent_id fields of the newly created objects (cf.
 l10n_be_intrastat_product as example).</p>
 </li>
 <li><p class="first">XML Files: Menu, Action, Views</p>
-<p>Cf. l10n_be_istrastat_product as example, replace “be” by your Country
-Code.</p>
+<p>Cf. l10n_be_istrastat_product as example, replace “be” by your
+Country Code.</p>
 </li>
 </ul>
 <p><strong>Other functionality added by this module:</strong></p>
@@ -499,7 +499,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><p class="first">Denis Roussel &lt;<a class="reference external" href="mailto:denis.roussel&#64;acsone.eu">denis.roussel&#64;acsone.eu</a>&gt;</p>
 </li>
-<li><p class="first">Tecnativa &lt;<a class="reference external" href="http://www.tecnativa.com&gt;">www.tecnativa.com\&gt;</a>:</p>
+<li><p class="first">Tecnativa &lt;<a class="reference external" href="http://www.tecnativa.com">www.tecnativa.com</a>&gt;:</p>
 <blockquote>
 <ul class="simple">
 <li>João Marques</li>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# generated from manifests external_dependencies
-python-stdnum>=1.16


### PR DESCRIPTION
This replaces the use of `is_valid` from the `stdnum.vatin` library with Odoo's validation logic in the VAT constraint check.

The `stdnum.vatin.is_valid()` function expects VAT numbers to be in international format, i.e., prefixed with the country code (e.g., `ESB66676008`), and will return False if the VAT is not prefixed. In contrast, the validation that's used in Odoo (https://github.com/odoo/odoo/blob/211629b232861b960f6650f980d1e3b6acac94d9/addons/base_vat/models/res_partner.py#L184) supports local VAT numbers (e.g., `B66676008`) without requiring the country prefix, because it combines the VAT value with the partner's `country_id`.