### PR TITLE
[UPD] intrastat_delivery: Added a different priority order to set the Incoterm: first from the partner, then from the delivery method, and finally from the general settings; if none are set, it will remain empty.

### DIFF
--- a/intrastat_delivery/README.rst
+++ b/intrastat_delivery/README.rst
@@ -40,6 +40,15 @@ from that sales order.
 It is recommended to set TRUE the "Show incoterms in orders and invoices" value at
 "Settings / Sales".
 
+Incoterm selection priority:
+
+When assigning the Incoterm to a sales order, the following priority is applied:
+
+1. First, the Incoterm set on the partner is used.
+2. If not defined, the Incoterm from the shipping method is used.
+3. If still not defined, the general settings Incoterm is used.
+4. If none of the above are set, the Incoterm field remains empty.
+
 **Table of contents**
 
 .. contents::
@@ -72,6 +81,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Aritz Olea <aritz.olea@factorlibre.com>
+* Diego Fernández <diego.fernandez@factorlibre.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/intrastat_delivery/__manifest__.py
+++ b/intrastat_delivery/__manifest__.py
@@ -11,6 +11,7 @@
         "sale_stock",
         "delivery",
         "intrastat_product",
+        "sale_partner_incoterm",
     ],
     "data": ["views/delivery_carrier_view.xml"],
     "installable": True,

--- a/intrastat_delivery/models/sale_order.py
+++ b/intrastat_delivery/models/sale_order.py
@@ -1,17 +1,59 @@
 # © 2023 FactorLibre - Aritz Olea <aritz.olea@factorlibre.com>
-from odoo import models
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    incoterm = fields.Many2one(
+        "account.incoterms",
+        compute="_compute_incoterm",
+        store=True,
+        readonly=False,
+    )
+
+    def _get_sale_type_incoterm(self):
+        """Check if type_id (sale_order_type module) exists and
+        consider its incoterm  if is defined."""
+        self.ensure_one()
+        if "type_id" in self._fields and self.type_id:
+            return getattr(self.type_id, "incoterm_id", False)
+        return False
+
+    def _get_default_incoterm(self):
+        self.ensure_one()
+        sale_type_inc = self._get_sale_type_incoterm()
+        return (
+            sale_type_inc
+            or self.partner_id.sale_incoterm_id
+            or self.carrier_id.incoterm
+            or self.company_id.incoterm_id
+            or self.env["account.incoterms"]
+        )
+
+    @api.depends(
+        "partner_id",
+        "partner_id.sale_incoterm_id",
+        "carrier_id",
+        "carrier_id.incoterm",
+        "company_id",
+        "company_id.incoterm_id",
+    )
+    def _compute_incoterm(self):
+        for order in self:
+            order.incoterm = order._get_default_incoterm()
+
     def _action_confirm(self):
         ret = super()._action_confirm()
         for order in self:
+            incoterm = order._get_default_incoterm()
+            intr_trans = (
+                order.carrier_id.intrastat_transport_id if order.carrier_id else False
+            )
             order.write(
                 {
-                    "incoterm": order.carrier_id.incoterm.id,
-                    "intrastat_transport_id": order.carrier_id.intrastat_transport_id.id,
+                    "incoterm": incoterm.id,
+                    "intrastat_transport_id": intr_trans.id if intr_trans else False,
                 }
             )
         return ret

--- a/intrastat_delivery/readme/CONTRIBUTORS.rst
+++ b/intrastat_delivery/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Aritz Olea <aritz.olea@factorlibre.com>
+* Diego Fernández <diego.fernandez@factorlibre.com>

--- a/intrastat_delivery/readme/DESCRIPTION.rst
+++ b/intrastat_delivery/readme/DESCRIPTION.rst
@@ -9,3 +9,12 @@ from that sales order.
 
 It is recommended to set TRUE the "Show incoterms in orders and invoices" value at
 "Settings / Sales".
+
+Incoterm selection priority:
+
+When assigning the Incoterm to a sales order, the following priority is applied:
+
+1. First, the Incoterm set on the partner is used.
+2. If not defined, the Incoterm from the shipping method is used.
+3. If still not defined, the general settings Incoterm is used.
+4. If none of the above are set, the Incoterm field remains empty.

--- a/intrastat_delivery/static/description/index.html
+++ b/intrastat_delivery/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -379,6 +379,14 @@ established in “Settings” will apply.</p>
 from that sales order.</p>
 <p>It is recommended to set TRUE the “Show incoterms in orders and invoices” value at
 “Settings / Sales”.</p>
+<p>Incoterm selection priority:</p>
+<p>When assigning the Incoterm to a sales order, the following priority is applied:</p>
+<ol class="arabic simple">
+<li>First, the Incoterm set on the partner is used.</li>
+<li>If not defined, the Incoterm from the shipping method is used.</li>
+<li>If still not defined, the general settings Incoterm is used.</li>
+<li>If none of the above are set, the Incoterm field remains empty.</li>
+</ol>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -416,12 +424,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul class="simple">
 <li>Aritz Olea &lt;<a class="reference external" href="mailto:aritz.olea&#64;factorlibre.com">aritz.olea&#64;factorlibre.com</a>&gt;</li>
+<li>Diego Fernández &lt;<a class="reference external" href="mailto:diego.fernandez&#64;factorlibre.com">diego.fernandez&#64;factorlibre.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/intrastat_delivery/tests/test_intrastat_delivery.py
+++ b/intrastat_delivery/tests/test_intrastat_delivery.py
@@ -24,6 +24,12 @@ class TestIntrastatDelivery(AccountTestInvoicingCommon):
         cls.incoterm = cls.env["account.incoterms"].create(
             {"name": "Incoterm", "code": "INC"}
         )
+        cls.incoterm_partner = cls.env["account.incoterms"].create(
+            {"name": "Partner INC", "code": "PIN"}
+        )
+        cls.incoterm_company = cls.env["account.incoterms"].create(
+            {"name": "Company INC", "code": "CIN"}
+        )
         cls.intrastat_transport_mode = cls.env["intrastat.transport_mode"].create(
             {"name": "Incoterm", "code": "INC", "description": "DESC"}
         )
@@ -40,11 +46,7 @@ class TestIntrastatDelivery(AccountTestInvoicingCommon):
             {
                 "partner_id": cls.partner_a.id,
                 "order_line": [
-                    Command.create(
-                        {
-                            "product_id": cls.product_1.id,
-                        }
-                    ),
+                    Command.create({"product_id": cls.product_1.id}),
                 ],
             }
         )
@@ -63,7 +65,7 @@ class TestIntrastatDelivery(AccountTestInvoicingCommon):
             self.order.intrastat_transport_id, self.env["intrastat.transport_mode"]
         )
         self.order.set_delivery_line(self.carrier, 0)
-        self.assertEqual(self.order.incoterm, self.env["account.incoterms"])
+        self.assertEqual(self.order.incoterm, self.incoterm)
         self.assertEqual(
             self.order.intrastat_transport_id, self.env["intrastat.transport_mode"]
         )
@@ -87,3 +89,45 @@ class TestIntrastatDelivery(AccountTestInvoicingCommon):
         invoice = self.order.invoice_ids[0]
         self.assertEqual(invoice.invoice_incoterm_id, self.incoterm)
         self.assertEqual(invoice.intrastat_transport_id, self.intrastat_transport_mode)
+
+    def test_02_priority_partner_over_carrier_and_company(self):
+        self.partner_a.sale_incoterm_id = self.incoterm_partner
+        self.env.company.incoterm_id = self.incoterm_company
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "carrier_id": self.carrier.id,
+                "order_line": [Command.create({"product_id": self.product_1.id})],
+            }
+        )
+        self.assertEqual(order.incoterm, self.incoterm_partner)
+        order.action_confirm()
+        self.assertEqual(order.incoterm, self.incoterm_partner)
+
+    def test_03_priority_carrier_when_no_partner(self):
+        self.partner_a.sale_incoterm_id = False
+        self.env.company.incoterm_id = self.incoterm_company
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "carrier_id": self.carrier.id,
+                "order_line": [Command.create({"product_id": self.product_1.id})],
+            }
+        )
+        self.assertEqual(order.incoterm, self.incoterm)
+        order.action_confirm()
+        self.assertEqual(order.incoterm, self.incoterm)
+        self.assertEqual(order.intrastat_transport_id, self.intrastat_transport_mode)
+
+    def test_04_priority_company_when_no_partner_nor_carrier(self):
+        self.partner_a.sale_incoterm_id = False
+        self.env.company.incoterm_id = self.incoterm_company
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "order_line": [Command.create({"product_id": self.product_1.id})],
+            }
+        )
+        self.assertEqual(order.incoterm, self.incoterm_company)
+        order.action_confirm()
+        self.assertEqual(order.incoterm, self.incoterm_company)


### PR DESCRIPTION
Added a different priority order to set the Incoterm: first from the partner, then from the delivery method, and finally from the general settings; if none are set, it will remain empty.
