### PR TITLE
[17.0][IMP] intrastat_product: Define the src_dest_country_id field readonly=False

### DIFF
--- a/intrastat_product/models/account_move.py
+++ b/intrastat_product/models/account_move.py
@@ -28,6 +28,7 @@ class AccountMove(models.Model):
         string="Origin/Destination Country",
         compute="_compute_src_dest_country_id",
         store=True,
+        readonly=False,
         help="Destination country for dispatches. Origin country for arrivals.",
     )
     src_dest_region_id = fields.Many2one(


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/intrastat-extrastat/pull/318

Define the `src_dest_country_id` field readonly=False

Example use case:
- Our company is based in France
- Create a sales order with a delivery address in France
- Confirm the sales order
- Validate the picking
- Create the invoice
- Although the `src_dest_country_id` is France, there are specific cases that may require changing the country (even when the invoice is confirmed); for example, if we have shipped the goods to a customer's logistics warehouse in France but then the customer moves the goods to another country (Ireland, for example), in that case we will need to change the country and define Ireland because it must appear on the Intrastat declaration.

Please @pedrobaeza and @juancarlosonate-tecnativa can you review it?

@Tecnativa TT58076