### PR TITLE
[16.0][FIX] intrastat_product: set the correct country code for Greece

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -17,6 +17,17 @@ from odoo.tools import float_is_zero
 _logger = logging.getLogger(__name__)
 
 
+SRC_DEST_COUNTRY_CODE_MAPPING = {
+    "GB": "XI",
+    "GR": "EL",
+}
+
+PRODUCT_ORIGIN_COUNTRY_CODE_MAPPING = {
+    "GB": "XU",
+    "GR": "EL",
+}
+
+
 class IntrastatProductDeclaration(models.Model):
     _name = "intrastat.product.declaration"
     _description = "Intrastat Product Declaration"
@@ -1167,8 +1178,7 @@ class IntrastatProductComputationLine(models.Model):
     def _compute_src_dest_country_code(self):
         for this in self:
             code = this.src_dest_country_id and this.src_dest_country_id.code or False
-            if code == "GB":
-                code = "XI"  # Northern Ireland
+            code = SRC_DEST_COUNTRY_CODE_MAPPING.get(code, code)
             this.src_dest_country_code = code
 
     @api.depends("product_origin_country_id")
@@ -1179,10 +1189,7 @@ class IntrastatProductComputationLine(models.Model):
                 and this.product_origin_country_id.code
                 or False
             )
-            if code == "GB":
-                code = "XU"
-                # XU can be used when you don't know if the product
-                # originate from Great-Britain or from Northern Ireland
+            code = PRODUCT_ORIGIN_COUNTRY_CODE_MAPPING.get(code, code)
             this.product_origin_country_code = code
 
     @api.constrains("vat")

--- a/intrastat_product/tests/test_intrastat_product.py
+++ b/intrastat_product/tests/test_intrastat_product.py
@@ -96,6 +96,16 @@ class TestIntrastatProduct(IntrastatProductCommon):
         declaration_line = declaration_line_form.save()
         self.assertEqual(declaration_line.src_dest_country_code, "FR")
 
+        # Test Greece country code conversion
+        declaration_line_form_greece = Form(
+            self.env["intrastat.product.declaration.line"].with_context(
+                default_parent_id=self.declaration.id
+            )
+        )
+        declaration_line_form_greece.src_dest_country_id = self.env.ref("base.gr")
+        declaration_line_form_greece = declaration_line_form.save()
+        self.assertEqual(declaration_line_form_greece.src_dest_country_code, "EL")
+
     def test_declaration_no_country(self):
         self.demo_company.country_id = False
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
Check correct country code for Greece. The correct is EL instead of GR.