### PR TITLE
[16.0][IMP] intrastat_product: Allow the inclusion of zero-value lines for goods movements related to repairs and maintenance

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -803,26 +803,55 @@ class IntrastatProductDeclaration(models.Model):
             )
 
             for line_vals in lines_current_invoice:
-                if (
-                    not line_vals["amount_company_currency"]
-                    and not line_vals["amount_accessory_cost_company_currency"]
-                    and not self.company_id.intrastat_include_zero_price_lines
-                ):
-                    inv_line = self.env["account.move.line"].browse(
-                        line_vals["invoice_line_id"]
-                    )
-                    _logger.info(
-                        "Skipping invoice line %s qty %s "
-                        "of invoice %s. Reason: price_subtotal = 0 "
-                        "and accessory costs = 0",
-                        inv_line.name,
-                        inv_line.quantity,
-                        inv_line.move_id.name,
-                    )
+                if not self._should_include_zero_price_line(line_vals):
                     continue
                 lines.append(line_vals)
 
         return lines
+
+    def _should_include_zero_price_line(self, line_vals):
+        """Check if a zero-price line should be included in the declaration.
+
+        Returns True if the line should be included, False if it should be
+        skipped. When included, updates line values with transaction 23
+        and the product's sale price.
+        """
+        if (
+            line_vals["amount_company_currency"]
+            or line_vals["amount_accessory_cost_company_currency"]
+        ):
+            return True
+        if not self.company_id.intrastat_include_zero_price_lines:
+            inv_line = self.env["account.move.line"].browse(
+                line_vals["invoice_line_id"]
+            )
+            _logger.info(
+                "Skipping invoice line %s qty %s "
+                "of invoice %s. Reason: price_subtotal = 0 "
+                "and accessory costs = 0",
+                inv_line.name,
+                inv_line.quantity,
+                inv_line.move_id.name,
+            )
+            return False
+        self._update_zero_price_line_vals(line_vals)
+        return True
+
+    def _update_zero_price_line_vals(self, line_vals):
+        """Update zero-price line values for Intrastat declaration.
+
+        When zero-price lines are included (e.g. warranty replacements),
+        they must use transaction code 23 and the product's sale price
+        as fiscal value, per EU Intrastat regulation.
+        """
+        tr_23 = self.env.ref("intrastat_product.intrastat_transaction_23")
+        line_vals["transaction_id"] = tr_23.id
+        inv_line = self.env["account.move.line"].browse(line_vals["invoice_line_id"])
+        product = inv_line.product_id
+        if product and product.list_price:
+            line_vals["amount_company_currency"] = (
+                product.list_price * inv_line.quantity
+            )
 
     def _prepare_html_note(self, notedict, key2label):
         note = ""

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -806,6 +806,7 @@ class IntrastatProductDeclaration(models.Model):
                 if (
                     not line_vals["amount_company_currency"]
                     and not line_vals["amount_accessory_cost_company_currency"]
+                    and not self.company_id.intrastat_include_zero_price_lines
                 ):
                     inv_line = self.env["account.move.line"].browse(
                         line_vals["invoice_line_id"]

--- a/intrastat_product/models/res_company.py
+++ b/intrastat_product/models/res_company.py
@@ -40,8 +40,10 @@ class ResCompany(models.Model):
     )
     intrastat_include_zero_price_lines = fields.Boolean(
         string="Include Intrastat Lines with Zero Price",
-        help="If checked, Intrastat lines with zero price will be added to the declaration,"
-        "zero price lines are normally for repairing and maintenance operations.",
+        help="If checked, Intrastat lines with zero price will be added to the "
+        "declaration with transaction code 23 (warranty replacement) and the "
+        "product's sale price as fiscal value. "
+        "Zero price lines are normally for repairing and maintenance operations.",
         default=False,
     )
 

--- a/intrastat_product/models/res_company.py
+++ b/intrastat_product/models/res_company.py
@@ -38,6 +38,12 @@ class ResCompany(models.Model):
     intrastat_accessory_costs = fields.Boolean(
         string="Include Accessory Costs in Fiscal Value of Product"
     )
+    intrastat_include_zero_price_lines = fields.Boolean(
+        string="Include Intrastat Lines with Zero Price",
+        help="If checked, Intrastat lines with zero price will be added to the declaration,"
+        "zero price lines are normally for repairing and maintenance operations.",
+        default=False,
+    )
 
     @api.model
     def _intrastat_arrivals(self):

--- a/intrastat_product/tests/test_intrastat_product.py
+++ b/intrastat_product/tests/test_intrastat_product.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from psycopg2 import IntegrityError
 
+from odoo import Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
@@ -157,6 +158,80 @@ class TestIntrastatProduct(IntrastatProductCommon):
     def test_invoice_report_with_intrastat_lines(self):
         self.invoice.compute_intrastat_lines()
         self._test_invoice_report(2)
+
+    def test_zero_price_lines_transaction_23(self):
+        """Zero price lines included in Intrastat must use transaction 23
+        and the product's sale price as fiscal value."""
+        self.demo_company.intrastat_include_zero_price_lines = True
+        product_c3po = self.product_c3po.product_variant_ids[0]
+        list_price = product_c3po.list_price
+        self.assertTrue(list_price, "Product must have a list_price for this test")
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "fiscal_position_id": self.position.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": product_c3po.id,
+                            "quantity": 3,
+                            "price_unit": 0.0,
+                            "name": "Warranty replacement",
+                        },
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        declaration = self.declaration_obj.create(
+            {
+                "company_id": self.demo_company.id,
+                "declaration_type": "dispatches",
+            }
+        )
+        declaration.action_gather()
+        zero_lines = declaration.computation_line_ids.filtered(
+            lambda l: l.invoice_line_id.move_id == invoice
+        )
+        self.assertEqual(len(zero_lines), 1)
+        tr_23 = self.env.ref("intrastat_product.intrastat_transaction_23")
+        self.assertEqual(zero_lines.transaction_id, tr_23)
+        self.assertEqual(zero_lines.amount_company_currency, list_price * 3)
+
+    def test_zero_price_lines_excluded_by_default(self):
+        """Zero price lines must be excluded when config is disabled."""
+        self.demo_company.intrastat_include_zero_price_lines = False
+        product_c3po = self.product_c3po.product_variant_ids[0]
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "fiscal_position_id": self.position.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": product_c3po.id,
+                            "quantity": 1,
+                            "price_unit": 0.0,
+                            "name": "Warranty replacement",
+                        },
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        declaration = self.declaration_obj.create(
+            {
+                "company_id": self.demo_company.id,
+                "declaration_type": "dispatches",
+            }
+        )
+        declaration.action_gather()
+        zero_lines = declaration.computation_line_ids.filtered(
+            lambda l: l.invoice_line_id.move_id == invoice
+        )
+        self.assertFalse(zero_lines)
 
 
 class TestIntrastatProductCase(TestIntrastatProduct, TransactionCase):

--- a/intrastat_product/views/res_config_settings.xml
+++ b/intrastat_product/views/res_config_settings.xml
@@ -58,6 +58,19 @@
                         />
                             </div>
                         </div>
+                <div class="col-12 o_setting_box">
+                    <div class="o_setting_left_pane">
+                            <field name="intrastat_include_zero_price_lines" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                            <div class="row">
+                                <label
+                                for="intrastat_include_zero_price_lines"
+                                class="col-12"
+                            />
+                        </div>
+                    </div>
+                </div>
             </div>
         </field>
     </record>

--- a/intrastat_product/wizards/res_config_settings.py
+++ b/intrastat_product/wizards/res_config_settings.py
@@ -26,3 +26,6 @@ class ResConfigSettings(models.TransientModel):
     )
     country_id = fields.Many2one(related="company_id.country_id")
     # country_code is defined in the 'account' module
+    intrastat_include_zero_price_lines = fields.Boolean(
+        related="company_id.intrastat_include_zero_price_lines", readonly=False
+    )


### PR DESCRIPTION
- It can be enabled in company settings if needed.
- Some companies perform maintenance and repair operations free of charge, but they are movements of goods, so they have to be included in intrastat declaration.
- In some countries is allowed to include this in intrastat declaration.

<img width="1357" height="555" alt="image" src="https://github.com/user-attachments/assets/9a365a50-e5ed-465e-afc2-1d53fb7f232d" />


https://www.boe.es/buscar/doc.php?id=BOE-A-2018-7021