### PR TITLE
[18.0][IMP]intrastat_product: improve search to avoid massive memory consumption

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -635,8 +635,11 @@ class IntrastatProductDeclaration(models.Model):
         self._gather_invoices_init(notedict)
         domain = self._prepare_invoice_domain()
         order = "journal_id, name"
-        invoices = self.env["account.move"].search(domain, order=order)
-
+        invoices = (
+            self.env["account.move"]
+            .with_context(prefetch_fields=False)
+            .search(domain, order=order)
+        )
         for invoice in invoices:
             lines_current_invoice = []
             total_inv_accessory_costs_cc = 0.0  # in company currency


### PR DESCRIPTION
The invoice search in the Intrastat declaration has been modified to optimize performance on large databases.
Previously, the query caused memory errors due to loading too many records and relational fields.
Now, `with_context(prefetch_fields=False)`  avoids unnecessary prefetch and significantly improving the action's speed and memory consumption.
I have attached comparative screenshots showing the response time before and after the change.

- Before changes with limit 10.000 (12,7 GB): 

<img width="2297" height="1002" alt="imagen" src="https://github.com/user-attachments/assets/c079f5f6-1748-49ab-beab-f70086e0cba9" />

- After changes without limit (1,3 GB):

<img width="2524" height="1089" alt="imagen" src="https://github.com/user-attachments/assets/7b50b6f2-a454-401c-a9ae-8bd4da30d02f" />
