### PR TITLE
[17.0][IMP] intrastat_product: Change Float fields (total_amount + amount_company_currency) to Monetary

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -131,10 +131,9 @@ class IntrastatProductDeclaration(models.Model):
         store=True,
         tracking=True,
     )
-    total_amount = fields.Float(
+    total_amount = fields.Monetary(
         compute="_compute_numbers",
         string="Total Fiscal Amount",
-        digits="Account",
         store=True,
         help="Total fiscal amount in company currency of the declaration.",
     )
@@ -1055,17 +1054,17 @@ class IntrastatProductComputationLine(models.Model):
         digits="Product Unit of Measure",
         help="Supplementary Units Quantity",
     )
-    amount_company_currency = fields.Float(
+    amount_company_currency = fields.Monetary(
         string="Fiscal Value",
-        digits="Account",
+        currency_field="company_currency_id",
         required=True,
         help="Amount in company currency to write in the declaration. "
         "Amount in company currency = amount in invoice currency "
         "converted to company currency with the rate of the invoice date.",
     )
-    amount_accessory_cost_company_currency = fields.Float(
+    amount_accessory_cost_company_currency = fields.Monetary(
         string="Accessory Costs",
-        digits="Account",
+        currency_field="company_currency_id",
         help="Amount in company currency of the accessory costs related to "
         "this invoice line. By default, these accessory costs are computed "
         "at the pro-rata of the amount of each invoice line.",
@@ -1260,9 +1259,9 @@ class IntrastatProductDeclarationLine(models.Model):
     suppl_unit_qty = fields.Integer(
         string="Suppl. Unit Qty", help="Supplementary Units Quantity"
     )
-    amount_company_currency = fields.Float(
+    amount_company_currency = fields.Monetary(
         string="Fiscal Value",
-        digits="Account",
+        currency_field="company_currency_id",
         help="Amount in company currency to write in the declaration. "
         "Amount in company currency = amount in invoice currency "
         "converted to company currency with the rate of the invoice date.",

--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -1209,18 +1209,8 @@ class IntrastatProductComputationLine(models.Model):
                 computation_line["amount_company_currency"]
                 + computation_line["amount_accessory_cost_company_currency"]
             )
-        # on computation lines, weight and suppl_unit_qty are floats
-        # on declaration lines, weight and suppl_unit_qty
-        # are integer => so we must round()
-        for field in fields_to_sum:
-            vals[field] = int(round(vals[field]))
-        # the intrastat specs say that, if the value is between 0 and 0.5,
-        # it should be rounded to 1
-        if not vals["weight"]:
-            vals["weight"] = 1
         if vals["intrastat_unit_id"] and not vals["suppl_unit_qty"]:
             vals["suppl_unit_qty"] = 1
-        vals["amount_company_currency"] = int(round(vals["amount_company_currency"]))
         vals["line_number"] = line_number
         return vals
 

--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -73,11 +73,7 @@
                         <group name="properties-2">
                             <field name="action" readonly="state == 'done'" />
                             <field name="revision" readonly="state == 'done'" />
-                            <field
-                                name="total_amount"
-                                widget="monetary"
-                                options="{'currency_field': 'currency_id'}"
-                            />
+                            <field name="total_amount" />
                             <field name="num_decl_lines" />
                             <field
                                 name="company_id"
@@ -247,16 +243,8 @@
                         required="reporting_level == 'extended'"
                         invisible="reporting_level != 'extended'"
                     />
-                    <field
-                        name="amount_company_currency"
-                        widget="monetary"
-                        options="{'currency_field': 'company_currency_id'}"
-                    />
-                    <field
-                        name="amount_accessory_cost_company_currency"
-                        widget="monetary"
-                        options="{'currency_field': 'company_currency_id'}"
-                    />
+                    <field name="amount_company_currency" />
+                    <field name="amount_accessory_cost_company_currency" />
                     <field name="company_currency_id" invisible="1" />
                     <field name="transaction_id" required="1" />
                     <label
@@ -416,11 +404,7 @@
                         name="src_dest_country_code"
                         invisible="reporting_level != 'extended'"
                     />
-                    <field
-                        name="amount_company_currency"
-                        widget="monetary"
-                        options="{'currency_field': 'company_currency_id'}"
-                    />
+                    <field name="amount_company_currency" />
                     <field name="company_currency_id" invisible="1" />
                     <field name="transaction_id" />
                     <label for="weight" invisible="reporting_level != 'extended'" />


### PR DESCRIPTION
Backport from 18.0: https://github.com/OCA/intrastat-extrastat/pull/339

Related to https://github.com/OCA/intrastat-extrastat/pull/335

Changes done:
- [x] Change Float fields (total_amount + amount_company_currency + amount_accessory_cost_company_currency) to Monetary (https://github.com/OCA/intrastat-extrastat/pull/335#issuecomment-4132744825 + https://github.com/OCA/intrastat-extrastat/pull/335#issuecomment-4133141233)
- [x] Remove unnecessary code (https://github.com/OCA/intrastat-extrastat/pull/335#issuecomment-4132956574)

Please @pedrobaeza and @alexis-via can you review it?


@Tecnativa TT61473