### PR TITLE
[18.0][IMP] intrastat_base: Define an appropriate "default" value for fiscal positions in account.chart.template

### DIFF
--- a/intrastat_base/models/__init__.py
+++ b/intrastat_base/models/__init__.py
@@ -1,4 +1,5 @@
 from . import product_template
 from . import res_company
+from . import account_chart_template
 from . import account_fiscal_position
 from . import account_move

--- a/intrastat_base/models/account_chart_template.py
+++ b/intrastat_base/models/account_chart_template.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+from odoo.addons.account.models.chart_template import template
+
+
+class AccountChartTemplate(models.AbstractModel):
+    _inherit = "account.chart.template"
+
+    @template(model="account.fiscal.position")
+    def _get_account_fiscal_position(self, template_code):
+        """Define the appropriate value (intrastat=no) as the default value, for
+        example when defining a chart of accounts in a company.
+        If specific values need to be defined for a chart of accounts, it will be
+        necessary to use the _get_fiscal_position() method, as is done in
+        l10n_es_intrastat_report.
+        """
+        res = super()._get_account_fiscal_position(template_code=template_code)
+        [v.update({"intrastat": "no"}) for v in res.values()]
+        return res

--- a/intrastat_base/models/account_fiscal_position.py
+++ b/intrastat_base/models/account_fiscal_position.py
@@ -11,6 +11,7 @@ class AccountFiscalPosition(models.Model):
 
     intrastat = fields.Selection(
         "_intrastat_selection",
+        default="no",
         help="When set to B2B or B2C, the invoices with this fiscal position will "
         "be taken into account for the generation of the intrastat reports.",
     )

--- a/intrastat_base/tests/__init__.py
+++ b/intrastat_base/tests/__init__.py
@@ -1,2 +1,1 @@
-from . import common
 from . import test_all

--- a/intrastat_base/tests/common.py
+++ b/intrastat_base/tests/common.py
@@ -1,8 +1,10 @@
 # Copyright 2021 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.addons.base.tests.common import BaseCommon
 
-class IntrastatCommon:
+
+class IntrastatCommon(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/intrastat_base/tests/test_all.py
+++ b/intrastat_base/tests/test_all.py
@@ -46,10 +46,6 @@ CSV_DATA = {
 class TestIntrastatBase(IntrastatCommon):
     """Tests for this module"""
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
     def test_company(self):
         # add 'Demo user' to intrastat_remind_user_ids
         self.demo_company.write(
@@ -68,6 +64,7 @@ class TestIntrastatBase(IntrastatCommon):
     def test_accessory(self):
         with self.assertRaises(ValidationError):
             self.shipping_cost.type = "consu"
+            self.shipping_cost.is_accessory_cost = True
 
     def test_fiscal_position(self):
         with self.assertRaises(ValidationError):

--- a/intrastat_base/tests/test_all.py
+++ b/intrastat_base/tests/test_all.py
@@ -1,6 +1,46 @@
+import io
+from unittest.mock import patch
+
 from odoo.exceptions import ValidationError
+from odoo.tools import mute_logger
+
+from odoo.addons.account.models.chart_template import AccountChartTemplate
 
 from .common import IntrastatCommon
+
+
+def _get_chart_template_mapping(self, get_all=False):
+    return {
+        "test": {
+            "name": "test",
+            "country_id": self.env.ref("base.be").id,
+            "country_code": None,
+            "module": "account",
+            "parent": None,
+        }
+    }
+
+
+def test_get_data(self, template_code):
+    """The template_data and res.company keys are required for proper operation."""
+    return {
+        "template_data": {},
+        "res.company": {
+            self.env.company.id: {},
+        },
+        "account.fiscal.position": {
+            "test_fiscal_position_template": {
+                "name": "Fiscal Position",
+            }
+        },
+    }
+
+
+CSV_DATA = {
+    "test_fiscal_position_template": (
+        '"id","name"\n' '"test_fiscal_position_template","Fiscal Position"\n'
+    ),
+}
 
 
 class TestIntrastatBase(IntrastatCommon):
@@ -46,3 +86,33 @@ class TestIntrastatBase(IntrastatCommon):
                     "intrastat": "b2c",
                 }
             )
+
+    @patch.object(
+        AccountChartTemplate, "_get_chart_template_mapping", _get_chart_template_mapping
+    )
+    @mute_logger("odoo.models.unlink")
+    def test_chart_template_fiscal_position(self):
+        """Similar to what test_parsed_csv_submodel_being_updated does in account
+        test_chart_template to check if the chart template has a tax position and the
+        data defined in it is not "correct", the correct "default" value will be
+        returned.
+        We cannot use generic_coa because it does not have tax position data.
+        """
+        with patch.object(
+            AccountChartTemplate,
+            "_get_chart_template_data",
+            side_effect=test_get_data,
+            autospec=True,
+        ):
+            self.chart_template_obj._load(
+                template_code="test", company=self.demo_company, install_demo=False
+            )
+        with patch(
+            "odoo.addons.account.models.chart_template.file_open",
+            side_effect=lambda *args: io.StringIO(
+                CSV_DATA["test_fiscal_position_template"]
+            ),
+        ):
+            data_fp = self.chart_template_obj._get_account_fiscal_position("test")
+        self.assertIn("test_fiscal_position_template", data_fp)
+        self.assertEqual(data_fp["test_fiscal_position_template"]["intrastat"], "no")


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/intrastat-extrastat/pull/333

Define an appropriate "default" value for fiscal positions in account.chart.template

It is important to define the appropriate value when defining an accounting plan for a company or, for example, when using `account_chart_update` module

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT61423