### PR TITLE
[17.0][IMP] intrastat_product: add amount_company_currency in list view of computation+decl lines

### DIFF
--- a/intrastat_product/views/intrastat_product_declaration.xml
+++ b/intrastat_product/views/intrastat_product_declaration.xml
@@ -311,6 +311,7 @@
                 <field name="declaration_type" column_invisible="1" />
                 <field name="reporting_level" column_invisible="1" />
                 <field name="company_country_code" column_invisible="1" />
+                <field name="company_currency_id" column_invisible="1" />
                 <field name="product_id" optional="show" />
                 <field
                     name="hs_code_id"
@@ -452,6 +453,7 @@
                 <field name="declaration_type" column_invisible="1" />
                 <field name="reporting_level" column_invisible="1" />
                 <field name="company_country_code" column_invisible="1" />
+                <field name="company_currency_id" column_invisible="1" />
                 <field
                     name="line_number"
                     optional="show"


### PR DESCRIPTION
BEFORE:

<img width="1163" height="575" alt="intrastat_v17-before" src="https://github.com/user-attachments/assets/e293a3e2-697e-4dc5-8721-2faf148acb1a" />

AFTER:

<img width="1144" height="592" alt="v17_after" src="https://github.com/user-attachments/assets/9ce9681f-c550-4fa7-b07a-b07168b36fd3" />

This is a small improvement on PR https://github.com/OCA/intrastat-extrastat/pull/341 by @victoralmau 