### PR TITLE
[FIX] intrastat_delivery: Losing incoterm when order does not have a …

### DIFF
--- a/intrastat_delivery/models/sale_order.py
+++ b/intrastat_delivery/models/sale_order.py
@@ -8,12 +8,13 @@ class SaleOrder(models.Model):
     def _action_confirm(self):
         ret = super()._action_confirm()
         for order in self:
-            order.write(
-                {
-                    "incoterm": order.carrier_id.incoterm.id,
-                    "intrastat_transport_id": order.carrier_id.intrastat_transport_id.id,
-                }
-            )
+            if order.carrier_id and order.carrier_id.incoterm:
+                order.write(
+                    {
+                        "incoterm": order.carrier_id.incoterm.id,
+                        "intrastat_transport_id": order.carrier_id.intrastat_transport_id.id,
+                    }
+                )
         return ret
 
     def _prepare_invoice(self):


### PR DESCRIPTION
### Module

intrastat_delivery

### Describe the bug

If a sale order without a carrier has an incoterm and you try to confirm it, after that, the order loses the incoterm because it tries to add the carrier one during the confirmation.

### To Reproduce

1. Create an order with different products and invoice policy based on "Delivered quantities".

(image from runboat OCA)

<img width="1914" height="958" alt="image" src="https://github.com/user-attachments/assets/268bec16-0415-48fe-bcad-61f21e484ebb" />

Confirming the order

<img width="1914" height="958" alt="image" src="https://github.com/user-attachments/assets/75772942-6727-4da8-a15c-df72b82be66c" />

With this change if an order has not a carrier, the incoterm will remain the same .

**Affected versions:**

16.0