### PR TITLE
[17.0][IMP] intrastat_product: Add a message if there is no weight

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -381,6 +381,9 @@ class IntrastatProductDeclaration(models.Model):
             weight = product_weight * source_uom._compute_quantity(
                 line_qty, product.uom_id
             )
+            if not weight:
+                msg = _("Missing weight on product %s.") % product.display_name
+                notedict["invoice"][notedict["inv_origin"]].add(msg)
         else:
             msg = _(
                 "Conversion from unit of measure <em>%(source_uom)s</em> to "


### PR DESCRIPTION
Add a message if there is no weight

Similar to what existed in v15 https://github.com/OCA/intrastat-extrastat/blob/a3ace05118668c3d2caaf257ee6cdca49a3b656b/intrastat_product/models/intrastat_product_declaration.py#L404 and removed in https://github.com/OCA/intrastat-extrastat/commit/3ec9eddbf310ba3be247f72f7ec1532d2b8be404#diff-74e1197466e3c9a2c08b006d373e86cca69ac389f34c9e4ed38dc24b84018d80L414

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT62349