### PR TITLE
[19.0][IMP] intrastat_product: Add a method to enable compatibility

### DIFF
--- a/intrastat_product/models/intrastat_product_declaration.py
+++ b/intrastat_product/models/intrastat_product_declaration.py
@@ -594,6 +594,20 @@ class IntrastatProductDeclaration(models.Model):
                         total_inv_accessory_costs_cc / len(lines_current_invoice)
                     )
 
+    def _invoice_domain_move_types(self):
+        """
+        This method returns the types to be used in _prepare_invoice_domain(); it is
+        important that it exists so that other modules (l10n_es_intrastat_report)
+        can modify it for Spanish declarations.
+        """
+        self.ensure_one()
+        move_types = ()
+        if self.declaration_type == "arrivals":
+            move_types = ("in_invoice", "in_refund")
+        elif self.declaration_type == "dispatches":
+            move_types = ("out_invoice", "out_refund")
+        return move_types
+
     def _prepare_invoice_domain(self):
         """
         Complete this method in the localization module
@@ -604,18 +618,14 @@ class IntrastatProductDeclaration(models.Model):
         """
         start_date = date(int(self.year), int(self.month), 1)
         end_date = start_date + relativedelta(day=1, months=+1, days=-1)
-        domain = (
+        return (
             Domain("date", ">=", start_date)
             & Domain("date", "<=", end_date)
             & Domain("state", "=", "posted")
             & Domain("intrastat_fiscal_position", "in", ("b2b", "b2c"))
             & Domain("company_id", "=", self.company_id.id)
+            & Domain("move_type", "in", self._invoice_domain_move_types())
         )
-        if self.declaration_type == "arrivals":
-            domain &= Domain("move_type", "in", ("in_invoice", "in_refund"))
-        elif self.declaration_type == "dispatches":
-            domain &= Domain("move_type", "in", ("out_invoice", "out_refund"))
-        return domain
 
     def _is_product(self, invoice_line):
         if (


### PR DESCRIPTION
Add a method to enable compatibility (related to https://github.com/OCA/l10n-spain/pull/5056)

**Before this change (v18)**:

In `intrastat_product`, the `_prepare_invoice_domain()` method generated a domain that specified the corresponding `move_type`: https://github.com/OCA/intrastat-extrastat/blob/e11b7d15a638d9fdc47fa0c0b906a0bffc87ba9d/intrastat_product/models/intrastat_product_declaration.py#L615
In `l10n_es_intrastat_report`, the `_prepare_invoice_domain()` method is overridden to bypass that condition https://github.com/OCA/l10n-spain/blob/4a23145bba6cd8fcbf5f15bbd18ada360cc2d9f7/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py#L75 and regenerate the appropriate move_type according to Spanish law.

**Now in v19**:
The domain is constructed using `Domain()`, so it is not possible to do `domain = super()._prepare_invoice_domain()[:-1]`.
Therefore, you would need to do something in `l10n_es_intrastat_report`, such as:
```

def _prepare_invoice_domain(self):
        # TODO: check with ES legislation
        """
        Both in_ and out_refund must be included in order to cover
        - credit notes with and without return
        - companies subject to arrivals or dispatches only
        """
        domain = super()._prepare_invoice_domain()
        if self.company_id.country_id.code != "ES":
            return super()._prepare_invoice_domain()
        if self.declaration_type == "arrivals":
            domain -= Domain("move_type", "in", ("in_invoice", "in_refund"))
            domain += Domain("move_type", "in", ("in_invoice", "out_refund"))
        elif self.declaration_type == "dispatches":
            domain -= Domain("move_type", "in", ("out_invoice", "out_refund"))
            domain += Domain("move_type", "in", ("out_invoice", "in_refund"))
        return domain
```

The `_invoice_domain_move_types()` method added in this module allows other modules to override it (`l10n_es_intrastat_report`) in a simple way: https://github.com/OCA/l10n-spain/pull/5056/changes# diff-0f4d0a4514e917dff73e15cc9c7b1a2ed4de47b3be88e05237a095f7a2effb45R68

Please @pedrobaeza can you review it?

@Tecnativa TT61941