### PR TITLE
[16.0][IMP] product_harmonized_system_stock: add ACL on HS.code to stock manager

### DIFF
--- a/product_harmonized_system_stock/__manifest__.py
+++ b/product_harmonized_system_stock/__manifest__.py
@@ -12,7 +12,7 @@
     "maintainers": ["alexis-via", "luc-demeyer"],
     "website": "https://github.com/OCA/intrastat-extrastat",
     "depends": ["product_harmonized_system", "stock"],
-    "data": ["views/hs_code_menu.xml"],
+    "data": ["views/hs_code_menu.xml", "security/ir.model.access.csv"],
     "installable": True,
     "auto_install": True,
 }

--- a/product_harmonized_system_stock/security/ir.model.access.csv
+++ b/product_harmonized_system_stock/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hs_code_group_stock_manager,Full access on hs.code to Stock Manager group,product_harmonized_system.model_hs_code,stock.group_stock_manager,1,1,1,1


### PR DESCRIPTION
product_harmonized_system_stock adds an "HS Code" menu entry in Inventory > Configuration, so it's logical to give the full rights to Inventory manager on HS codes. In the current implementation, the Stock Manager can see the menu entry under Inventory > Configuration but he cannot change the configuration of HS Codes !

If you agree with this change, I'll forward port it.