### PR TITLE
[18.0][FIX] product_harmonized_system: Restore the local code uniqueness

### DIFF
--- a/product_harmonized_system/__manifest__.py
+++ b/product_harmonized_system/__manifest__.py
@@ -10,7 +10,7 @@
 
 {
     "name": "Product Harmonized System Codes",
-    "version": "18.0.2.0.0",
+    "version": "18.0.2.0.1",
     "category": "Reporting",
     "license": "AGPL-3",
     "summary": "Base module for Product Import/Export reports",

--- a/product_harmonized_system/migrations/18.0.2.0.1/pre-migration.py
+++ b/product_harmonized_system/migrations/18.0.2.0.1/pre-migration.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Tecnativa - Carlos Dauden
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from openupgradelib import openupgrade
+from openupgradelib.openupgrade_merge_records import merge_records
+
+_logger = logging.getLogger(__name__)
+
+
+def _get_duplicated_codes(env):
+    """Return the groups of H.S. codes sharing the same local code.
+
+    Every group is a list of record ids sorted by the criteria electing the
+    record to keep, which therefore comes first:
+
+    1. The records owning an external ID, so the data of the module that
+       declared them still resolves. Otherwise that module would recreate the
+       record on its next update and reintroduce the duplicate.
+    2. The active ones, as the archived records are the discarded leftovers.
+    3. The oldest one, as it is the one the historical documents point to.
+    """
+    env.cr.execute(
+        """
+        WITH code AS (
+            SELECT
+                hc.id,
+                hc.local_code,
+                hc.active,
+                EXISTS (
+                    SELECT 1 FROM ir_model_data imd
+                    WHERE imd.model = 'hs.code' AND imd.res_id = hc.id
+                ) AS has_xmlid
+            FROM hs_code hc
+        )
+        SELECT
+            local_code,
+            array_agg(id ORDER BY has_xmlid DESC, active DESC NULLS LAST, id)
+        FROM code
+        GROUP BY local_code
+        HAVING count(id) > 1
+        """
+    )
+    return env.cr.fetchall()
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Merge the H.S. codes sharing the same local code.
+
+    The `local_code_uniq` constraint introduced in this version is silently
+    skipped with a warning when the table already holds duplicates, so they
+    have to be gone before the module tables are updated.
+    """
+    for local_code, ids in _get_duplicated_codes(env):
+        keep_id, drop_ids = ids[0], tuple(ids[1:])
+        _logger.info(
+            "H.S. codes %s merged into %s as they all use the local code %s",
+            list(drop_ids),
+            keep_id,
+            local_code,
+        )
+        # Keep the external IDs of the discarded records resolving to the kept
+        # one instead of leaving them dangling.
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE ir_model_data SET res_id = %(keep_id)s
+            WHERE model = 'hs.code' AND res_id IN %(drop_ids)s
+            """,
+            {"keep_id": keep_id, "drop_ids": drop_ids},
+            skip_no_result=True,
+        )
+        # Recover the descriptions only filled in the discarded records, and
+        # unarchive the kept one when any of them was still in use.
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE hs_code hc SET
+                description = COALESCE(hc.description, (
+                    SELECT d.description FROM hs_code d
+                    WHERE d.id IN %(drop_ids)s AND d.description IS NOT NULL
+                    ORDER BY d.id LIMIT 1
+                )),
+                long_description = COALESCE(hc.long_description, (
+                    SELECT d.long_description FROM hs_code d
+                    WHERE d.id IN %(drop_ids)s AND d.long_description IS NOT NULL
+                    ORDER BY d.id LIMIT 1
+                )),
+                active = COALESCE(hc.active, FALSE) OR EXISTS (
+                    SELECT 1 FROM hs_code d
+                    WHERE d.id IN %(drop_ids)s AND d.active
+                )
+            WHERE hc.id = %(keep_id)s
+            """,
+            {"keep_id": keep_id, "drop_ids": drop_ids},
+        )
+        # Redirect every record referencing the discarded codes and delete them
+        merge_records(env, "hs.code", drop_ids, keep_id, method="sql")

--- a/product_harmonized_system/models/hs_code.py
+++ b/product_harmonized_system/models/hs_code.py
@@ -88,6 +88,14 @@ class HSCode(models.Model):
             name = shorten(name, 55)
             this.display_name = name
 
+    _sql_constraints = [
+        (
+            "local_code_uniq",
+            "unique(local_code)",
+            "An H.S. code with this local code already exists !",
+        )
+    ]
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:

--- a/product_harmonized_system/readme/CONTRIBUTORS.md
+++ b/product_harmonized_system/readme/CONTRIBUTORS.md
@@ -2,3 +2,5 @@
 - Luc De Meyer, Noviat \<<info@noviat.com>\>
 - Kumar Aberer, brain-tec AG \<<kumar.aberer@braintec-group.com>\>
 - Nhan Tran \<<nhant@trobz.com>\>
+- [Tecnativa](https://www.tecnativa.com):
+  - Carlos Dauden

--- a/product_harmonized_system/security/product_hs_security.xml
+++ b/product_harmonized_system/security/product_hs_security.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<odoo noupdate="1">
-    <record id="hs_code_company_rule" model="ir.rule">
-        <field name="name">HS Code Company rule</field>
-        <field name="model_id" ref="model_hs_code" />
-        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
-    </record>
-</odoo>

--- a/product_harmonized_system/tests/__init__.py
+++ b/product_harmonized_system/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_hs_code

--- a/product_harmonized_system/tests/test_hs_code.py
+++ b/product_harmonized_system/tests/test_hs_code.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Tecnativa - Carlos Dauden
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from psycopg2 import IntegrityError
+
+from odoo.tests import Form, TransactionCase
+from odoo.tools import mute_logger
+
+
+class TestHsCode(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.hs_code_model = cls.env["hs.code"]
+        cls.hs_code = cls._create_hs_code("12345678")
+
+    @classmethod
+    def _create_hs_code(cls, local_code):
+        """Create an H.S. code the way the user does it from its form view."""
+        hs_code_form = Form(cls.hs_code_model)
+        hs_code_form.local_code = local_code
+        return hs_code_form.save()
+
+    def test_local_code_uniq(self):
+        with mute_logger("odoo.sql_db"), self.assertRaises(IntegrityError):
+            self._create_hs_code("12345678")
+
+    def test_local_code_uniq_spaces_ignored(self):
+        """Spaces are stripped on save, so this is the same code as the existing
+        one and must be rejected as well."""
+        with mute_logger("odoo.sql_db"), self.assertRaises(IntegrityError):
+            self._create_hs_code("1234 5678")
+
+    def test_local_code_uniq_archived(self):
+        """An archived code still reserves its local code."""
+        self.hs_code.action_archive()
+        with mute_logger("odoo.sql_db"), self.assertRaises(IntegrityError):
+            self._create_hs_code("12345678")
+
+    def test_local_code_uniq_write(self):
+        """Renaming a code into an existing one is rejected too."""
+        other_hs_code = self._create_hs_code("87654321")
+        with mute_logger("odoo.sql_db"), self.assertRaises(IntegrityError):
+            other_hs_code.local_code = "12345678"
+            other_hs_code.flush_recordset()


### PR DESCRIPTION
Removing company_id from hs.code (https://github.com/OCA/intrastat-extrastat/pull/311) also dropped the whole _sql_constraints block, and with it local_code_company_uniq, without any replacement. Since then nothing prevents two H.S. codes from sharing the same local code, which silently breaks the declarations grouping their lines by that code. The constraint comes back as local_code_uniq, now without company_id, as the codes are standard at EU level and no longer belong to a company.

The pre-migration script is required because the ORM only logs a warning and skips the constraint when the table already holds duplicates. It merges every group of records sharing a local code into the one owning an external ID, so the data of the module that declared it still resolves instead of being recreated as a new duplicate on its next update, then the active one, then the oldest. Everything referencing the discarded records is redirected to the kept one, which also recovers the descriptions only they had and is unarchived when any of them was still in use. Databases coming from 17.0 are the main target, as back then the same local code was allowed once per company.

Also removes security/product_hs_security.xml, left behind in the tree when it was dropped from the manifest: it is not loaded any more and its record rule filters on the removed company_id.

@Tecnativa
ping @sergio-teruel @carlos-lopez-tecnativa 